### PR TITLE
altered routine slightly allowing for temp

### DIFF
--- a/scarlet2/nn.py
+++ b/scarlet2/nn.py
@@ -39,12 +39,12 @@ def pad_fwd(x, model_size=32):
     data_size = x.shape[1]
     pad = True
     pad_gap = model_size - data_size
-    assert pad_gap>= 0, "Model size must be larger than max box size"
+    assert pad_gap >= 0, "Model size must be larger than max box size"
     # dont pad if we dont need to
     if pad_gap == 0:
         pad = False
     # calculate how much to pad    
-    if pad_gap % 2 == 0:
+    elif pad_gap % 2 == 0:
         pad_lo = pad_hi = int(pad_gap / 2)
     else:
         pad_lo = int(pad_gap // 2)
@@ -81,7 +81,7 @@ def pad_back(x, pad_lo, pad_hi):
 
 
 # calculate score function (jacobian of log-probability)
-def calc_grad(x, model, model_size=32):
+def calc_grad(x, model, model_size=32, t=0.02):
     """Calculates the gradient of the log-prior 
     using the ScoreNet model chosen
     
@@ -91,21 +91,21 @@ def calc_grad(x, model, model_size=32):
     model : the model to calculate the score function
     model_size : int
         size of the model to be used
+    t : float for the temperature to evaluate the score function
         
     Returns
     -------
     score_func : array of the score function
     """
-    # perform padding if needed
     x = jnp.float32(x) # cast to float32
     x, pad_lo, pad_hi, pad = pad_fwd(x, model_size)
     assert (x.shape[1] % 32) == 0, f"image size must be 32 or 64, got: {x.shape[1]}"
     if jnp.ndim(x) == 2:
         x = jnp.expand_dims(x, axis=0)
-        score_func = model(x)
+        score_func = model(x,t=t)
         score_func = jnp.squeeze(score_func, axis=0)
     else:
-        score_func = model(x)
+        score_func = model(x,t=t)
     # return to original size
     if pad: 
         score_func = pad_back(score_func, pad_lo, pad_hi)
@@ -123,17 +123,17 @@ def vgrad(f, x):
 # such that for gradient calls in jax, the score prior
 # is returned
 from functools import partial
-@partial(custom_vjp, nondiff_argnums=(0,1,2))
-def _log_prob(model, transform, model_size, x):
+@partial(custom_vjp, nondiff_argnums=(0,1,2,3))
+def _log_prob(model, transform, model_size, temperature, x):
     return 0
     
-def log_prob_fwd(model, transform, model_size, x):
+def log_prob_fwd(model, transform, model_size, temperature, x):
     x = transform(x)
-    score_func = calc_grad(x, model, model_size)
+    score_func = calc_grad(x, model, model_size, temperature)
     score_func = vgrad(transform, x) * score_func # chain rule
     return 0.0, score_func  # cannot directly call log_prob in Class object
 
-def log_prob_bwd(model, transform, model_size, res, g):
+def log_prob_bwd(model, transform, model_size, temperature, res, g):
     score_func = res # Get residuals computed in f_fwd
     return (g * score_func,) # create the vector (g) jacobian (score_func) product
 
@@ -146,9 +146,10 @@ class ScorePrior(dist.Distribution):
     support = constraints.real_vector
     """Prior distribution based on a neural network"""
 
-    def __init__(self, model='None', transform='None', model_size=32, validate_args=None):
+    def __init__(self, model='None', transform='None', model_size=32, temperature=0.02, validate_args=None):
         self.model = model 
         self.model_size = model_size    
+        self.temperature = temperature
         if transform == 'None':
             self.transform = lambda x: x
         else:
@@ -168,4 +169,4 @@ class ScorePrior(dist.Distribution):
         raise NotImplementedError
     
     def log_prob(self, x):
-        return _log_prob(self.model, self.transform, self.model_size, x)
+        return _log_prob(self.model, self.transform, self.model_size, self.temperature, x)


### PR DESCRIPTION
Model now compatible for a user define temperature to be sure during model construction via something akin to  'prior = nn.ScorePrior(model=prior_model, transform=transform, model_size=64, temperature=0.1)' Defaults are set inside the model call, instead of the score network architecture for more modular code.