### PR TITLE
Parameters with priors and constraints

### DIFF
--- a/scarlet2/nn.py
+++ b/scarlet2/nn.py
@@ -113,18 +113,15 @@ def vgrad(f, x):
 # is returned
 from functools import partial
 
-
 @partial(custom_vjp, nondiff_argnums=(0, 1))
 def _log_prob(model, transform, x):
     return 0
 
-
 def log_prob_fwd(model, transform, x):
-    x = transform(x)
-    score_func = calc_grad(x, model)
+    x_ = transform(x)
+    score_func = calc_grad(x_, model)
     score_func = vgrad(transform, x) * score_func  # chain rule
     return 0.0, score_func  # cannot directly call log_prob in Class object
-
 
 def log_prob_bwd(model, transform, res, g):
     score_func = res  # Get residuals computed in f_fwd

--- a/scarlet2/nn.py
+++ b/scarlet2/nn.py
@@ -85,14 +85,13 @@ def calc_grad(x, model):
     score_func : array of the score function
     """
     # cast to float32, expand to (batch, shape), and pad to match the shape of the score model
-    # TODO: allow for score models with dimensions other than 2
     x_, pad = pad_fwd(jnp.float32(x), model.shape)
 
     # run score model, expects (batch, shape)
-    if jnp.ndim(x) == 2:
+    if jnp.ndim(x) == len(model.shape):
         x_ = jnp.expand_dims(x_, axis=0)
     score_func = model(x_)
-    if jnp.ndim(x) == 2:
+    if jnp.ndim(x) == len(model.shape):
         score_func = jnp.squeeze(score_func, axis=0)
 
     # remove padding

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -223,6 +223,8 @@ def _make_step(model, observations, optim, opt_state, filter_spec=None, constrai
     def loss_fn(model):
         if constraint_fn is not None:
             # parameters now obey constraints
+            # transformation happens in the grad path, so gradients are wrt to unconstrained variables
+            # likelihood and prior grads transparently apply the Jacobians of these transformations
             model = _constraint_replace(model, constraint_fn)
 
         pred = model()


### PR DESCRIPTION
Following the discussion in #34, this PR brings a correction to the treatment of `ScorePrior`. In particular, there is no `ScorePrior.transform` anymore because these transformations are already applied _before_ the prior gets to see the parameters. Autodiff then takes care of the Jacobians, so we simply don't need to track them.

In addition, I streamlined the padding code. And the score model implementation can now also deal with arbitrary dimensions, so we can specify priors on SED, etc.

