### PR TITLE
Update nn.py

### DIFF
--- a/scarlet2/nn.py
+++ b/scarlet2/nn.py
@@ -150,7 +150,7 @@ class ScorePrior(dist.Distribution):
         return _log_prob(self.model, x)
 
 # define a class for temperature adjustable prior
-class TempScore:
+class TempScore(ScorePrior):
     """Temperature adjustable ScorePrior"""
     def __init__(self, model, temp=0.02):
         self.model = model


### PR DESCRIPTION
TempScore class needs to be derived class of ScorePrior with new implementation and galaxygrad versions. Single line fix, tested and working.

Example usage:
```
temp = 0.02
prior = nn.TempScore(model=HSC_ScoreNet64, temp=temp)
```