### PR TITLE
Lanczos resampling renderer

### DIFF
--- a/scarlet2/fft.py
+++ b/scarlet2/fft.py
@@ -34,7 +34,7 @@ def transform(image, fft_shape, axes=None):
 
     image = _pad(image, fft_shape, axes)
     image = jnp.fft.ifftshift(image, axes)
-    image_fft = jnp.fft.fftn(image, axes=axes)
+    image_fft = jnp.fft.rfftn(image, axes=axes)
     return image_fft
 
 

--- a/scarlet2/fft.py
+++ b/scarlet2/fft.py
@@ -29,7 +29,9 @@ def transform(image, fft_shape, axes=None):
             axes = (axes,)
 
     if len(fft_shape) != len(axes):
-        msg = "fft_shape self.axes must have the same number of dimensions, got {0}, {1}"
+        msg = (
+            "fft_shape self.axes must have the same number of dimensions, got {0}, {1}"
+        )
         raise ValueError(msg.format(fft_shape, axes))
 
     image = _pad(image, fft_shape, axes)
@@ -88,8 +90,15 @@ def convolve(image, kernel, padding=3, axes=None, fft_shape=None, return_fft=Fal
     axes: tuple or None
         Axes that contain the spatial information for the PSFs.
     """
-    return _kspace_op(image, kernel, operator.mul, padding=padding, axes=axes, fft_shape=fft_shape,
-                      return_fft=return_fft)
+    return _kspace_op(
+        image,
+        kernel,
+        operator.mul,
+        padding=padding,
+        axes=axes,
+        fft_shape=fft_shape,
+        return_fft=return_fft,
+    )
 
 
 def deconvolve(image, kernel, padding=3, axes=None, fft_shape=None, return_fft=False):
@@ -110,11 +119,20 @@ def deconvolve(image, kernel, padding=3, axes=None, fft_shape=None, return_fft=F
         Axes that contain the spatial information for the PSFs.
     """
 
-    return _kspace_op(image, kernel, operator.truediv, padding=padding, fft_shape=fft_shape, axes=axes,
-                      return_fft=return_fft)
+    return _kspace_op(
+        image,
+        kernel,
+        operator.truediv,
+        padding=padding,
+        fft_shape=fft_shape,
+        axes=axes,
+        return_fft=return_fft,
+    )
 
 
-def _kspace_op(image, kernel, f, padding=3, axes=None, fft_shape=None, return_fft=False):
+def _kspace_op(
+    image, kernel, f, padding=3, axes=None, fft_shape=None, return_fft=False
+):
     if axes is None:
         axes = range(len(image.shape))
     else:
@@ -126,11 +144,15 @@ def _kspace_op(image, kernel, f, padding=3, axes=None, fft_shape=None, return_ff
     # assumes kernel FFT has been computed with large enough shape to cover also image
     if kernel.dtype in (jnp.complex64, jnp.complex128):
         fft_shape = [kernel.shape[ax] for ax in axes]
-        fft_shape[-1] = 2 * (fft_shape[-1] - 1)  # real-valued FFT has 1/2 of the frequencies
+        fft_shape[-1] = 2 * (
+            fft_shape[-1] - 1
+        )  # real-valued FFT has 1/2 of the frequencies
         kernel_fft = kernel
     else:
         if fft_shape is None:
-            fft_shape = _get_fast_shape(image.shape, kernel.shape, padding=padding, axes=axes)
+            fft_shape = _get_fast_shape(
+                image.shape, kernel.shape, padding=padding, axes=axes
+            )
         kernel_fft = transform(kernel, fft_shape, axes=axes)
 
     image_fft = transform(image, fft_shape, axes=axes)
@@ -139,6 +161,7 @@ def _kspace_op(image, kernel, f, padding=3, axes=None, fft_shape=None, return_ff
         return image_fft_
     image_ = inverse(image_fft_, fft_shape, image.shape, axes=axes)
     return image_
+
 
 def _get_fast_shape(im_or_shape1, im_or_shape2, axes=None, padding=3, max_shape=False):
     """Return the fast fft shapes for each spatial axis
@@ -221,6 +244,7 @@ def _fast_zero_pad(arr, pad_width):
     start = tuple(start for start, end in pad_width)
     result = jax.lax.dynamic_update_slice(result, arr, start_indices=start)
     return result
+
 
 def _pad(arr, newshape, axes=None, mode="constant", constant_values=0):
     """Pad an array to fit into newshape

--- a/scarlet2/fft.py
+++ b/scarlet2/fft.py
@@ -34,7 +34,7 @@ def transform(image, fft_shape, axes=None):
 
     image = _pad(image, fft_shape, axes)
     image = jnp.fft.ifftshift(image, axes)
-    image_fft = jnp.fft.rfftn(image, axes=axes)
+    image_fft = jnp.fft.fftn(image, axes=axes)
     return image_fft
 
 
@@ -139,7 +139,6 @@ def _kspace_op(image, kernel, f, padding=3, axes=None, fft_shape=None, return_ff
         return image_fft_
     image_ = inverse(image_fft_, fft_shape, image.shape, axes=axes)
     return image_
-
 
 def _get_fast_shape(im_or_shape1, im_or_shape2, axes=None, padding=3, max_shape=False):
     """Return the fast fft shapes for each spatial axis

--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -1,6 +1,7 @@
 import astropy.wcs.wcs
 import equinox as eqx
 import jax.numpy as jnp
+import numpy as np
 
 from .bbox import Box
 from .psf import PSF
@@ -8,21 +9,30 @@ from .psf import PSF
 
 class Frame(eqx.Module):
     bbox: Box
+    pixel_size: jnp.ndarray
     psf: PSF = None
     wcs: astropy.wcs.wcs = None
     channels: list
 
-    def __init__(self, bbox, psf=None, wcs=None, channels=None):
+    def __init__(self, bbox, pixel_size, psf=None, wcs=None, channels=None):
         self.bbox = bbox
         self.psf = psf
         self.wcs = wcs
+        self.pixel_size=pixel_size
         if channels is None:
             channels = list(range(bbox.shape[0]))
         assert len(channels) == bbox.shape[0]
+
         self.channels = channels
 
     def __hash__(self):
         return hash(self.bbox)
+
+    def get_pixel_scale(self):
+        """Compute the pixel scale in arcsec from WCS
+        """
+        d = self.wcs.pixel_to_world(0, 1, 0) - self.wcs_hsc.pixel_to_world(0, 2, 0)
+        return np.abs(d).dms.s
 
     def get_pixel(self, sky_coord):
         """Get the pixel coordinate from a world coordinate
@@ -34,8 +44,8 @@ class Frame(eqx.Module):
         """
         sky = jnp.asarray(sky_coord, dtype=jnp.float64).reshape(-1, 2)
 
-        if self._wcs is not None:
-            wcs_ = self._wcs.celestial  # only use celestial portion
+        if self.wcs is not None:
+            wcs_ = self.wcs.celestial  # only use celestial portion
             pixel = jnp.array(wcs_.world_to_pixel_values(sky)).reshape(-1, 2)
             # y/x instead of x/y:
             pixel = jnp.flip(pixel, axis=-1)
@@ -44,6 +54,8 @@ class Frame(eqx.Module):
 
         if pixel.size == 2:  # only one coordinate pair
             return pixel[0]
+        print(self)
+        print("pixel", pixel)
         return pixel
 
     def get_sky_coord(self, pixel):
@@ -56,14 +68,246 @@ class Frame(eqx.Module):
         """
         pix = jnp.asarray(pixel, dtype=np.float64).reshape(-1, 2)
 
-        if self._wcs is not None:
-            wcs_ = self._wcs.celestial  # only use celestial portion
+        if self.wcs is not None:
+            wcs = self.wcs.celestial  # only use celestial portion
             # x/y instead of y/x:
             pix = jnp.flip(pix, axis=-1)
-            sky = jnp.array(wcs_.pixel_to_world_values(pix))
+            sky = jnp.array(wcs.pixel_to_world_values(pix))
         else:
             sky = pix
 
         if sky.size == 2:
             return sky[0]
         return sky
+
+    def convert_pixel_to(self, target, pixel=None):
+        """Converts pixel coordinates from this frame to `target` Frame
+
+        Parameters
+        ----------
+        target: `~scarlet.Frame`
+            target frame
+        pixel: `tuple` or list ((y1,y2, ...), (x1, x2, ...))
+            pixel coordinates in this frame
+            If not set, convert all pixels in this frame
+
+        Returns
+        -------
+        coord_target: `tuple`
+            coordinates at the location of `coord` in the target frame
+        """
+        if pixel is None:
+            y, x = np.indices(self.bbox.shape[-2:], dtype=np.float64)
+            pixel = np.stack((y.flatten(), x.flatten()), axis=1)
+
+        ra_dec = self.get_sky_coord(pixel)
+        pixel_ = target.get_pixel(ra_dec)
+
+        if pixel_.size == 2:  # only one coordinate pair
+            return pixel_[0]
+        return pixel_
+
+    @staticmethod
+    def from_observations(
+        observations, model_psf=None, model_wcs=None, obs_id=None, coverage="union"
+    ):
+        """Generates a suitable model frame for a set of observations.
+
+        This method generates a frame from a set of observations by identifying the highest resolution
+        and the smallest PSF and use them to construct a common frame for all observations.
+
+        Parameters
+        ----------
+        observations: array of `scarlet.Observation` objects
+            array that contains Observations to match onto a common frame
+        model_psf: `scarlet.PSF`
+            PSF of the model frame, to which all observations are to be deconvolved.
+            If None, uses the smallest PSF across all observations and channels.
+        model_wcs: `astropy.wcs.WCS`
+            WCS for the model frame. If None, uses transformation of the observation
+            with the smallest pixels.
+        obs_id: int
+            index of the reference observation
+            If set to None, uses the observation with the smallest pixels.
+        coverage: "union" or "intersection"
+            Sets the frame to incorporate the pixels covered by any observation ('union')
+            or by all observations ('intersection').
+        """
+        assert coverage in ["union", "intersection"]
+
+        if not hasattr(observations, "__iter__"):
+            observations = (observations,)
+
+        # Array of pixel sizes for each observation
+        pix_tab = []
+        # Array of psf size for each psf of each observation
+        fat_psf_size = None
+        small_psf_size = None
+        channels = []
+        # Create frame channels and find smallest and largest psf
+        for c, obs in enumerate(observations):
+
+            # Concatenate all channels
+            channels = channels + obs.frame.channels
+
+            # concatenate all pixel sizes
+            h_temp = get_pixel_size(get_affine(obs.frame.wcs))
+
+            pix_tab.append(h_temp)
+            # Looking for the sharpest and the fatest psf
+            psf = obs.frame.psf.morphology
+            for psf in psf:
+                psf_size = get_psf_size(psf) * h_temp
+                if (fat_psf_size is None) or (psf_size > fat_psf_size):
+                    fat_psf_size = psf_size
+                if (obs_id is None) or (c == obs_id):
+                    if (model_psf is None) and (
+                        (small_psf_size is None) or (psf_size < small_psf_size)
+                    ):
+                        small_psf_size = psf_size
+                        model_psf_temp = ImagePSF(psf[np.newaxis, :, :])
+                        psf_h = h_temp
+
+        # Find a reference observation. Either provided by obs_id or as the observation with the smallest pixel
+        if obs_id is None:
+            obs_ref = observations[np.where(pix_tab == np.min(pix_tab))[0][0]]
+        else:
+            # Frame defined from obs_id
+            obs_ref = observations[obs_id]
+
+        # Reference wcs
+        if model_wcs is None:
+            model_wcs = obs_ref.frame.wcs
+
+        # Scale of the smallest pixel
+        pixel_size = obs_ref.pixel_size
+        h = get_pixel_size(get_affine(model_wcs))
+        
+        
+        # # If needed and psf is not provided: interpolate psf to smallest pixel
+        # if model_psf is None:
+        #     # If the reference PSF is not at the highest pixel resolution, make it!
+        #     if psf_h > h:
+        #         angle, h = interpolation.get_angles(model_wcs, obs.wcs)
+        #         model_psf = PSF(
+        #             interpolation.sinc_interp_inplace(model_psf_temp, psf_h, h, angle)
+        #         )
+        #     else:
+        #         model_psf = model_psf_temp
+        
+        # Dummy frame for WCS computations
+        model_shape = (len(channels), 0, 0)
+        
+
+
+        # print("model_shape", model_shape)
+        # print("channels", channels)
+        # print("model_psf", model_psf)
+        # print("model_wcs", model_wcs)
+
+
+        model_frame = Frame(
+            jnp.zeros(model_shape), pixel_size=pixel_size, channels=channels, psf=model_psf, wcs=model_wcs
+        )
+
+        # Determine overlap of all observations in pixel coordinates of the model frame
+        for c, obs in enumerate(observations):
+
+            if model_frame.wcs is obs.frame.wcs:
+                this_box = obs_ref.frame.bbox[-2:]
+            else:
+                obs_coord = obs.frame.convert_pixel_to(model_frame)
+                y_min = np.floor(np.min(obs_coord[:, 0])).astype("int")
+                x_min = np.floor(np.min(obs_coord[:, 1])).astype("int")
+                y_max = np.ceil(np.max(obs_coord[:, 0])).astype("int")
+                x_max = np.ceil(np.max(obs_coord[:, 1])).astype("int")
+                this_box = Box.from_bounds((y_min, y_max + 1), (x_min, x_max + 1))
+
+            if c == 0:
+                model_box = this_box
+            else:
+                if coverage == "union":
+                    model_box |= this_box
+                else:
+                    model_box &= this_box
+
+        # pad by the size of the widest psf to prevent leakage across the frame edge
+        ny, nx = model_box.shape
+        pad_size = fat_psf_size / h / 2
+        offset = (np.round(pad_size).astype("int"), np.round(pad_size).astype("int"))
+        model_box -= offset
+        # print("model_box", model_box)
+        # print("model_box.shape", model_box.shape)
+        model_box_shape = tuple(s + 2 * o for s, o in zip(model_box.shape, offset))
+
+        # move the reference pixel of the model wcs to the 0/0 pixel of the new shape
+        model_wcs = model_wcs.deepcopy()
+        model_wcs.wcs.crpix -= model_box.origin
+        model_wcs.array_shape = model_box.shape
+
+        # recreate the model frame with the correct shape
+        #frame_shape = (len(channels), model_box_shape)
+        frame_shape = np.concatenate([[len(channels)], np.array(model_box_shape)])
+        # print("frame_shape", frame_shape)
+        model_frame = Frame(
+            jnp.zeros(frame_shape), pixel_size=pixel_size, channels=channels, psf=model_psf, wcs=model_wcs
+        )
+
+        # Match observations to this frame
+        for obs in observations:
+            obs.match(model_frame)
+
+        return model_frame
+
+
+def get_psf_size(psf):
+    """ Measures the size of a psf by computing the size of the area in 3 sigma around the center.
+
+    This is an approximate method to estimate the size of the psf for setting the size of the frame,
+    which does not require a precise measurement.
+
+    Parameters
+    ----------
+        PSF: `scarlet.PSF` object
+            PSF for whic to compute the size
+    Returns
+    -------
+        sigma3: `float`
+            radius of the area inside 3 sigma around the center in pixels
+    """
+    # Normalisation by maximum
+    psf_frame = psf / np.max(psf)
+
+    # Pixels in the FWHM set to one, others to 0:
+    psf_frame[psf_frame > 0.5] = 1
+    psf_frame[psf_frame <= 0.5] = 0
+
+    # Area in the FWHM:
+    area = np.sum(psf_frame)
+
+    # Diameter of this area
+    d = 2 * (area / np.pi) ** 0.5
+
+    # 3-sigma:
+    sigma3 = 3 * d / (2 * (2 * np.log(2)) ** 0.5)
+
+    return sigma3
+
+
+def get_affine(wcs):
+    try:
+        model_affine = wcs.wcs.pc
+    except AttributeError:
+        model_affine = wcs.cd
+
+    return model_affine
+
+
+def get_pixel_size(model_affine):
+    """ Extracts the pixel size from a wcs
+    """
+    pix = np.sqrt(
+        np.abs(model_affine[0, 0])
+        * np.abs(model_affine[1, 1] - model_affine[0, 1] * model_affine[1, 0])
+    )
+    return pix

--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -190,7 +190,7 @@ class Frame(eqx.Module):
         model_shape = (len(channels), 0, 0)
 
         model_frame = Frame(
-            jnp.zeros(model_shape), channels=channels, psf=model_psf, wcs=model_wcs
+            Box(model_shape), channels=channels, psf=model_psf, wcs=model_wcs
         )
 
         # Determine overlap of all observations in pixel coordinates of the model frame
@@ -232,7 +232,7 @@ class Frame(eqx.Module):
         frame_shape = np.concatenate([[len(channels)], np.array(model_box_shape)])
 
         model_frame = Frame(
-            jnp.zeros(frame_shape), channels=channels, psf=model_psf, wcs=model_wcs
+            Box(frame_shape), channels=channels, psf=model_psf, wcs=model_wcs
         )
 
         # Match observations to this frame

--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -18,7 +18,7 @@ class Frame(eqx.Module):
         self.bbox = bbox
         self.psf = psf
         self.wcs = wcs
-        self.pixel_size = get_pixel_size(get_affine(self.wcs))*60*60 # in arcsec
+        self.pixel_size = get_pixel_size(get_affine(self.wcs)) * 60 * 60  # in arcsec
         if channels is None:
             channels = list(range(bbox.shape[0]))
         assert len(channels) == bbox.shape[0]
@@ -48,8 +48,6 @@ class Frame(eqx.Module):
 
         if pixel.size == 2:  # only one coordinate pair
             return pixel[0]
-        print(self)
-        print("pixel", pixel)
         return pixel
 
     def get_sky_coord(self, pixel):
@@ -175,7 +173,7 @@ class Frame(eqx.Module):
 
         # Scale of the smallest pixel
         h = get_pixel_size(get_affine(model_wcs))
-        
+
         # TODO:
         # # If needed and psf is not provided: interpolate psf to smallest pixel
         # if model_psf is None:
@@ -187,10 +185,10 @@ class Frame(eqx.Module):
         #         )
         #     else:
         #         model_psf = model_psf_temp
-        
+
         # Dummy frame for WCS computations
         model_shape = (len(channels), 0, 0)
-        
+
         model_frame = Frame(
             jnp.zeros(model_shape), channels=channels, psf=model_psf, wcs=model_wcs
         )
@@ -221,7 +219,7 @@ class Frame(eqx.Module):
         pad_size = fat_psf_size / h / 2
         offset = (np.round(pad_size).astype("int"), np.round(pad_size).astype("int"))
         model_box -= offset
-        
+
         model_box_shape = tuple(s + 2 * o for s, o in zip(model_box.shape, offset))
 
         # move the reference pixel of the model wcs to the 0/0 pixel of the new shape
@@ -230,7 +228,7 @@ class Frame(eqx.Module):
         model_wcs.array_shape = model_box.shape
 
         # recreate the model frame with the correct shape
-        #frame_shape = (len(channels), model_box_shape)
+        # frame_shape = (len(channels), model_box_shape)
         frame_shape = np.concatenate([[len(channels)], np.array(model_box_shape)])
 
         model_frame = Frame(
@@ -245,7 +243,7 @@ class Frame(eqx.Module):
 
 
 def get_psf_size(psf):
-    """ Measures the size of a psf by computing the size of the area in 3 sigma around the center.
+    """Measures the size of a psf by computing the size of the area in 3 sigma around the center.
 
     This is an approximate method to estimate the size of the psf for setting the size of the frame,
     which does not require a precise measurement.
@@ -288,8 +286,7 @@ def get_affine(wcs):
 
 
 def get_pixel_size(model_affine):
-    """ Extracts the pixel size from a wcs
-    """
+    """Extracts the pixel size from a wcs"""
     pix = np.sqrt(
         np.abs(model_affine[0, 0])
         * np.abs(model_affine[1, 1] - model_affine[0, 1] * model_affine[1, 0])

--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -1,23 +1,27 @@
 import jax
 import jax.numpy as jnp
 
-def f_1(x,n):
+
+def f_1(x, n):
     """
     We should Taylor expand instead
     (see galsim code)
     """
-    return x*0.+1.
+    return x * 0.0 + 1.0
 
-def f_2(x,n):
+
+def f_2(x, n):
     px = jnp.pi * x
     return n * jnp.sin(px) * jnp.sin(px / n) / px / px
 
+
 from functools import partial
+
 
 def lanczos_n(x, n=3):
     """
     Lanczos interpolation kernel
-    
+
     Parameters
     ----------
     n: Lanczos order
@@ -25,10 +29,10 @@ def lanczos_n(x, n=3):
     small_x = jnp.abs(x) <= 1e-4
     window_n = jnp.abs(x) <= n
 
-    return jnp.piecewise(x, 
-                         [small_x, (~small_x) & window_n], 
-                         [f_1, f_2, lambda x,n: jnp.array(0)], n
-                        )
+    return jnp.piecewise(
+        x, [small_x, (~small_x) & window_n], [f_1, f_2, lambda x, n: jnp.array(0)], n
+    )
+
 
 def resample2d(signal, coords, warp, n=3):
     """
@@ -46,7 +50,7 @@ def resample2d(signal, coords, warp, n=3):
             - x-coordinates are coords[0,:,0]
             - y-coordinates are coords[:,0,1]
     warp: array
-        Coordinates on which to resample the signal. 
+        Coordinates on which to resample the signal.
         shape:[nx, ny, 2]
         [ [[0,  0], [0,  1], ...,  [0,  N-1]],
                            [ ... ],
@@ -58,50 +62,48 @@ def resample2d(signal, coords, warp, n=3):
     resampled_signal: array
     """
 
-    x = warp[...,0].flatten()
-    y = warp[...,1].flatten()
- 
-    coords_x = coords[0,:,0]
-    coords_y = coords[:,0,1]
+    x = warp[..., 0].flatten()
+    y = warp[..., 1].flatten()
+
+    coords_x = coords[0, :, 0]
+    coords_y = coords[:, 0, 1]
 
     h = coords_x[1] - coords_x[0]
-    
-    xi = jnp.floor((x-coords_x[0])/h).astype(jnp.int32)
-    yi = jnp.floor((y-coords_y[0])/h).astype(jnp.int32)
+
+    xi = jnp.floor((x - coords_x[0]) / h).astype(jnp.int32)
+    yi = jnp.floor((y - coords_y[0]) / h).astype(jnp.int32)
 
     Nx = coords.shape[0]
     Ny = coords.shape[1]
-    
+
     def body_fun_x(i, args):
         res, yind, ky, masky = args
-        
+
         xind = xi + i
         maskx = (xind >= 0) & (xind < Ny)
 
-        kx = lanczos_n(
-            (x - coords_x[xind])/h,
-            n)
+        kx = lanczos_n((x - coords_x[xind]) / h, n)
 
-        k = kx*ky
+        k = kx * ky
         mask = maskx & masky
         res += jnp.where(mask, k * signal[yind, xind], 0)
-        
+
         return res, yind, ky, masky
 
     def body_fun_y(i, args):
         res = args
-        
+
         yind = yi + i
         masky = (yind >= 0) & (yind < Nx)
 
-        ky = lanczos_n(
-            (y - coords_y[yind])/h, 
-            n)
-        
-        res = jax.lax.fori_loop(-n, n+1, body_fun_x, (res, yind, ky, masky))[0]
-        
+        ky = lanczos_n((y - coords_y[yind]) / h, n)
+
+        res = jax.lax.fori_loop(-n, n + 1, body_fun_x, (res, yind, ky, masky))[0]
+
         return res
 
-    res = jax.lax.fori_loop(-n, n+1, body_fun_y, jnp.zeros_like(x).astype(signal.dtype))
-    
-    return res.reshape(warp[...,0].shape)
+    res = jax.lax.fori_loop(
+        -n, n + 1, body_fun_y, jnp.zeros_like(x).astype(signal.dtype)
+    )
+
+    return res.reshape(warp[..., 0].shape)

--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -1,0 +1,107 @@
+import jax
+import jax.numpy as jnp
+
+def f_1(x,n):
+    """
+    We should Taylor expand instead
+    (see galsim code)
+    """
+    return x*0.+1.
+
+def f_2(x,n):
+    px = jnp.pi * x
+    return n * jnp.sin(px) * jnp.sin(px / n) / px / px
+
+from functools import partial
+
+def lanczos_n(x, n=3):
+    """
+    Lanczos interpolation kernel
+    
+    Parameters
+    ----------
+    n: Lanczos order
+    """
+    small_x = jnp.abs(x) <= 1e-4
+    window_n = jnp.abs(x) <= n
+
+    return jnp.piecewise(x, 
+                         [small_x, (~small_x) & window_n], 
+                         [f_1, f_2, lambda x,n: jnp.array(0)], n
+                        )
+
+def resample2d(signal, coords, warp, n=3):
+    """
+    Resample a 2-dimensional image using a Lanczos kernel
+
+    Parameters
+    ----------
+    signal: array
+        2d array containing the signal. We assume here that the coordinates of
+        the signal
+        shape: [Nx, Ny]
+    coords: array
+        Coordinates on which the signal is sampled.
+        shape: [Nx, Ny, 2]
+            - x-coordinates are coords[0,:,0]
+            - y-coordinates are coords[:,0,1]
+    warp: array
+        Coordinates on which to resample the signal. 
+        shape:[nx, ny, 2]
+        [ [[0,  0], [0,  1], ...,  [0,  N-1]],
+                           [ ... ],
+          [[N-1,0], [N-1,1], ...,  [N-1,N  ]] ]
+    n: Lanczos order
+
+    Returns
+    -------
+    resampled_signal: array
+    """
+
+    x = warp[...,0].flatten()
+    y = warp[...,1].flatten()
+ 
+    coords_x = coords[0,:,0]
+    coords_y = coords[:,0,1]
+
+    h = coords_x[1] - coords_x[0]
+    
+    xi = jnp.floor((x-coords_x[0])/h).astype(jnp.int32)
+    yi = jnp.floor((y-coords_y[0])/h).astype(jnp.int32)
+
+    Nx = coords.shape[0]
+    Ny = coords.shape[1]
+    
+    def body_fun_x(i, args):
+        res, yind, ky, masky = args
+        
+        xind = xi + i
+        maskx = (xind >= 0) & (xind < Nx)
+
+        kx = lanczos_n(
+            (x - coords_x[xind])/h,
+            n)
+
+        k = kx*ky
+        mask = maskx & masky
+        res += jnp.where(mask, k * signal[yind, xind], 0)
+        
+        return res, yind, ky, masky
+
+    def body_fun_y(i, args):
+        res = args
+        
+        yind = yi + i
+        masky = (yind >= 0) & (yind < Ny)
+
+        ky = lanczos_n(
+            (y - coords_y[yind])/h, 
+            n)
+        
+        res = jax.lax.fori_loop(-n, n+1, body_fun_x, (res, yind, ky, masky))[0]
+        
+        return res
+
+    res = jax.lax.fori_loop(-n, n+1, body_fun_y, jnp.zeros_like(x).astype(signal.dtype))
+    
+    return res.reshape(warp[...,0].shape)

--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -4,10 +4,15 @@ import jax.numpy as jnp
 
 def f_1(x, n):
     """
-    We should Taylor expand instead
-    (see galsim code)
+    Approximation from galsim
+    // res = n/(pi x)^2 * sin(pi x) * sin(pi x / n)
+    //     ~= (1 - 1/6 pix^2) * (1 - 1/6 pix^2 / n^2)
+    //     = 1 - 1/6 pix^2 ( 1 + 1/n^2 )
     """
-    return x * 0.0 + 1.0
+    px = jnp.pi * x
+    temp = 1./6. * px * px
+    res = 1. - temp * (1. + 1. / (n * n))
+    return res
 
 
 def f_2(x, n):

--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -76,7 +76,7 @@ def resample2d(signal, coords, warp, n=3):
         res, yind, ky, masky = args
         
         xind = xi + i
-        maskx = (xind >= 0) & (xind < Nx)
+        maskx = (xind >= 0) & (xind < Ny)
 
         kx = lanczos_n(
             (x - coords_x[xind])/h,
@@ -92,7 +92,7 @@ def resample2d(signal, coords, warp, n=3):
         res = args
         
         yind = yi + i
-        masky = (yind >= 0) & (yind < Ny)
+        masky = (yind >= 0) & (yind < Nx)
 
         ky = lanczos_n(
             (y - coords_y[yind])/h, 

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -66,7 +66,7 @@ class Observation(Module):
             if self.frame.psf != frame.psf:
                 if frame.pixel_size != self.frame.pixel_size:
                     # 2) Deconvolve with the model PSF, returns Fourier space image
-                    renderers.append(KDeconvRenderer(frame, self.frame))
+                    renderers.append(KDeconvRenderer(frame))
 
                     # 3)a) Resample at the obs resolution
                     renderers.append(KResampleRenderer(frame, self.frame))
@@ -83,7 +83,7 @@ class Observation(Module):
                     # # which is more modular but also more expensive unless all operations remain in Fourier space
 
                     # Convolve with obs PSF and return real image
-                    renderers.append(KConvolveRenderer(frame, self.frame))
+                    renderers.append(KConvolveRenderer(self.frame))
 
                 else:
                     renderers.append(ConvolutionRenderer(frame, self.frame))

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -4,7 +4,15 @@ import jax.numpy as jnp
 from .bbox import Box
 from .frame import Frame
 from .module import Module, Parameter
-from .renderer import Renderer, NoRenderer, ConvolutionRenderer, ChannelRenderer, KDeconvRenderer, KResampleRenderer, KConvolveRenderer
+from .renderer import (
+    Renderer,
+    NoRenderer,
+    ConvolutionRenderer,
+    ChannelRenderer,
+    KDeconvRenderer,
+    KResampleRenderer,
+    KConvolveRenderer,
+)
 
 
 class Observation(Module):
@@ -43,7 +51,7 @@ class Observation(Module):
         D = jnp.prod(jnp.asarray(data.shape)) - jnp.sum(self.weights == 0)
         log_norm = D / 2 * jnp.log(2 * jnp.pi)
         log_like = -jnp.sum(self.weights * (model_ - data) ** 2) / 2
-        return log_like - log_norm  
+        return log_like - log_norm
 
     def match(self, frame, renderer=None):
         # choose the renderer
@@ -73,7 +81,7 @@ class Observation(Module):
                     # # Can be done by passing the renderer up to here to ConvolutionRenderer constructor below
                     # # Alternative: deconvolve from model_psf before 2) and convolve with full PSF in 3)
                     # # which is more modular but also more expensive unless all operations remain in Fourier space
-                    
+
                     # Convolve with obs PSF and return real image
                     renderers.append(KConvolveRenderer(frame, self.frame))
 
@@ -88,7 +96,8 @@ class Observation(Module):
                 renderer = eqx.nn.Sequential(renderers)
         else:
             assert isinstance(renderer, (Renderer, eqx.nn.Sequential))
-            assert renderer(jnp.zeros(frame.bbox.shape)).shape == self.frame.bbox.shape, \
-                "Renderer does not map model frame to observation frame"
-        object.__setattr__(self, 'renderer', renderer)
+            assert (
+                renderer(jnp.zeros(frame.bbox.shape)).shape == self.frame.bbox.shape
+            ), "Renderer does not map model frame to observation frame"
+        object.__setattr__(self, "renderer", renderer)
         return self

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -9,22 +9,20 @@ from .renderer import Renderer, NoRenderer, ConvolutionRenderer, ChannelRenderer
 
 class Observation(Module):
     data: jnp.ndarray
-    pixel_size: jnp.ndarray
     weights: jnp.ndarray
     frame: Frame = eqx.field(static=True)
     renderer: (Renderer, eqx.nn.Sequential) = eqx.field(static=True)
 
-    def __init__(self, data, pixel_size, weights, psf=None, wcs=None, channels=None, renderer=None):
+    def __init__(self, data, weights, psf=None, wcs=None, channels=None, renderer=None):
         # TODO: replace by DataStore class, and make that static
         self.data = Parameter(jnp.asarray(data), fixed=True)
         self.weights = Parameter(jnp.asarray(weights), fixed=True)
         if channels is None:
             channels = range(data.shape[0])
-        self.frame = Frame(Box(data.shape), jnp.asarray(pixel_size), psf, wcs, channels)
+        self.frame = Frame(Box(data.shape), psf, wcs, channels)
         if renderer is None:
             renderer = NoRenderer()
         self.renderer = renderer
-        self.pixel_size = Parameter(jnp.asarray(pixel_size), fixed=True) 
         super().__post_init__()
 
     def render(self, model):
@@ -76,6 +74,7 @@ class Observation(Module):
             # # Can be done by passing the renderer up to here to ConvolutionRenderer constructor below
             # # Alternative: deconvolve from model_psf before 2) and convolve with full PSF in 3)
             # # which is more modular but also more expensive unless all operations remain in Fourier space
+            
             # if self.frame.psf != frame.psf:
             #     renderers.append(ConvolutionRenderer(frame, self.frame))
             #     print('Am I here?')

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -4,14 +4,14 @@ import jax.numpy as jnp
 from .bbox import Box
 from .frame import Frame
 from .module import Module, Parameter
-from .renderer import Renderer, NoRenderer, ConvolutionRenderer
+from .renderer import Renderer, NoRenderer, ConvolutionRenderer, ChannelRenderer
 
 
 class Observation(Module):
     data: jnp.ndarray
     weights: jnp.ndarray
     frame: Frame = eqx.field(static=True)
-    renderer: Renderer = eqx.field(static=True)
+    renderer: (Renderer, eqx.nn.Sequential) = eqx.field(static=True)
 
     def __init__(self, data, weights, psf=None, wcs=None, channels=None, renderer=None):
         # TODO: replace by DataStore class, and make that static
@@ -48,29 +48,37 @@ class Observation(Module):
     def match(self, frame, renderer=None):
         # choose the renderer
         if renderer is None:
-            if self.frame.psf is frame.psf:
+            renderers = []
+
+            # note the order of renderers!
+            # 1) collapse channels that are not needed
+            if self.frame.channels != frame.channels:
+                renderers.append(ChannelRenderer(frame, self.frame))
+
+            # 2) TODO: rotate and resample to obs orientation
+            # angle, h = interpolation.get_angles(self.wcs, frame.wcs)
+            # same_res = abs(h - 1) < np.finfo(float).eps
+            # same_rot = (np.abs(angle[1]) ** 2) < np.finfo(float).eps
+
+            # 3) convolve with obs PSF
+            # TODO: if 2) is a resampling operation: model PSF needs to be resampled accordingly
+            # Can be done by passing the renderer up to here to ConvolutionRenderer constructor below
+            # Alternative: deconvolve from model_psf before 2) and convolve with full PSF in 3)
+            # which is more modular but also more expensive unless all operations remain in Fourier space
+            if self.frame.psf != frame.psf:
+                renderers.append(ConvolutionRenderer(frame, self.frame))
+
+            # 4) TODO: trim off the edges
+
+            if len(renderers) == 0:
                 renderer = NoRenderer()
+            elif len(renderers) == 1:
+                renderer = renderers[0]
             else:
-                assert self.frame.psf is not None and frame.psf is not None
-                if self.frame.wcs is frame.wcs:
-                    # same or None wcs: ConvolutionRenderer
-                    renderer = ConvolutionRenderer(frame, self.frame)
-                else:
-                    raise NotImplementedError
-                    # # if wcs shows changes in resolution or orientation:
-                    # # use ResolutionRenderer
-                    # assert self.frame.wcs is not None and model_frame.wcs is not None
-                    # angle, h = interpolation.get_angles(self.wcs, model_frame.wc
-                    # s)
-                    # same_res = abs(h - 1) < np.finfo(float).eps
-                    # same_rot = (np.abs(angle[1]) ** 2) < np.finfo(float).eps
-                    # if same_res and same_rot:
-                    #     renderer = ConvolutionRenderer(
-                    #         self, model_frame, convolution_type="fft"
-                    #     )
-                    # else:
-                    #     renderer = ResolutionRenderer(self, model_frame)
+                renderer = eqx.nn.Sequential(renderers)
         else:
-            assert isinstance(renderer, Renderer)
+            assert isinstance(renderer, (Renderer, eqx.nn.Sequential))
+            assert renderer(jnp.zeros(frame.bbox.shape)).shape == self.frame.bbox.shape, \
+                "Renderer does not map model frame to observation frame"
         object.__setattr__(self, 'renderer', renderer)
         return self

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -97,13 +97,13 @@ class KDeconvRenderer(Renderer):
 
     def __init__(self, model_frame, padding=None):
 
-        if padding==None:
+        if padding == None:
             # use 4 times padding
             pad_factor = 4
-            padding = pad_factor * max(model_frame.bbox.shape[1],
-                                       model_frame.bbox.shape[2])
+            padding = pad_factor * max(
+                model_frame.bbox.shape[1], model_frame.bbox.shape[2]
+            )
         object.__setattr__(self, "_pad_size", padding)
-
 
         # create PSF model
         psf = model_frame.psf()
@@ -137,11 +137,10 @@ class KResampleRenderer(Renderer):
         object.__setattr__(self, "_in_res", model_frame.pixel_size)
         object.__setattr__(self, "_out_res", obs_frame.pixel_size)
 
-        if padding==None:
+        if padding == None:
             # use 4 times padding
             pad_factor = 4
-            padding = pad_factor * max(obs_frame.bbox.shape[1],
-                                       obs_frame.bbox.shape[2])
+            padding = pad_factor * max(obs_frame.bbox.shape[1], obs_frame.bbox.shape[2])
 
         # find on what grid we will interpolate
         fft_out_shape = _get_fast_shape(
@@ -188,11 +187,10 @@ class KConvolveRenderer(Renderer):
     def __init__(self, obs_frame, padding=None):
         object.__setattr__(self, "_obs_shape", obs_frame.bbox.shape)
 
-        if padding==None:
+        if padding == None:
             # use 4 times padding
             pad_factor = 4
-            padding = pad_factor * max(obs_frame.bbox.shape[1],
-                                       obs_frame.bbox.shape[2])
+            padding = pad_factor * max(obs_frame.bbox.shape[1], obs_frame.bbox.shape[2])
         object.__setattr__(self, "_pad_size", padding)
 
         # get PSF from obs

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -1,8 +1,11 @@
 import equinox as eqx
 import jax.numpy as jnp
+import jax
 
-from .fft import convolve, deconvolve, _get_fast_shape
+from .fft import convolve, deconvolve, _get_fast_shape, transform, inverse
 
+from .interpolation import resample2d
+# from jii import _lanczos_interp2d, resample2d_
 
 class Renderer(eqx.Module):
     def __call__(self, model, key=None):  # key is needed to chain renderers with eqx.nn.Sequential
@@ -65,9 +68,136 @@ class ConvolutionRenderer(Renderer):
             psf_model = psf
         # make sure fft uses a shape large enough to cover the convolved model
         fft_shape = _get_fast_shape(model_frame.bbox.shape, psf_model.shape, padding=3, axes=(-2, -1))
+
         # compute and store diff kernel in Fourier space
         diff_kernel_fft = deconvolve(obs_frame.psf(), psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True)
         object.__setattr__(self, "_diff_kernel_fft", diff_kernel_fft)
 
     def __call__(self, model, key=None):
         return convolve(model, self._diff_kernel_fft, axes=(-2, -1))
+
+class KDeconvRenderer(Renderer):
+    """
+    Perform decovolution in Fourier space and return the Fourier decovolved
+    model
+    """
+    def __init__(self, model_frame, obs_frame):
+        # create PSF model
+        psf = model_frame.psf()
+        if len(psf.shape) == 2:  # only one image for all bands
+            # print("I am tiling the psf")
+            psf_model = jnp.tile(psf, (model_frame.bbox.shape[0], 1, 1))
+        else:
+            psf_model = psf
+        object.__setattr__(self, "_psf_model", psf_model)
+
+    def __call__(self, model, key=None):
+        # print(model)
+        psf_model = self._psf_model
+        # print(model.shape)
+        # print(psf_model.shape)
+        fft_shape = _get_fast_shape(model.shape, psf_model.shape, padding=1000, axes=(-2, -1))
+        print()
+        deconv_ = deconvolve(model, psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True)
+        # print(deconv_.dtype)
+        return deconv_
+
+class KResampleRenderer(Renderer):
+    """
+    Perform resampling in Fourier space
+    
+    Should get as input a Fourier image sampled at the model frame resolution
+    Needs to return a Fourier image sampled at the observation frame resolution
+    """ 
+    def __init__(self, model_frame, obs_frame): 
+        object.__setattr__(self, "_in_res", model_frame.pixel_size)
+        object.__setattr__(self, "_out_res", obs_frame.pixel_size)
+
+        # find on what grid we will interpolate
+        fft_out_shape = _get_fast_shape(obs_frame.bbox.shape, obs_frame.psf().shape, padding=300, axes=(-2, -1))
+        object.__setattr__(self, "_fft_out_shape", fft_out_shape)
+
+        # compute resolution ratio for flux conservation
+        object.__setattr__(self, "_resolution_ratio", obs_frame.pixel_size/model_frame.pixel_size)
+
+
+    def __call__(self, kimage, key=None):
+
+        # compute model k-coordinates of the fourier input image
+        ky_in = jnp.linspace(-.5, .5, kimage.shape[1]) / self._in_res
+        # kx_in = jnp.linspace(0, .5, kimage.shape[1]//2+1) / self._in_res
+        kx_in = jnp.linspace(-.5, .5, kimage.shape[1]) / self._in_res
+
+        ky_out = jnp.linspace(-.5, .5, self._fft_out_shape[0]) / self._out_res
+        # kx_out = jnp.linspace(0, .5, self._fft_out_shape[0]//2+1) / self._out_res
+        kx_out = jnp.linspace(-.5, .5, self._fft_out_shape[0]) / self._out_res
+        # print(kx_in)
+        # print(kx_out)
+        kimage = jnp.fft.fftshift(kimage, (-2, -1))
+
+        kcoords_in = jnp.stack(
+            jnp.meshgrid(kx_in, 
+                         ky_in
+                         ),
+              -1
+              )
+        
+        kcoords_out = jnp.stack(
+            jnp.meshgrid(
+                kx_out,
+                ky_out
+            ),
+            -1
+        )
+        
+        # import jii
+        k_resampled = jax.vmap(
+            resample2d,
+            in_axes=(0, None, None, None))(
+                kimage,
+                kcoords_in,
+                kcoords_out,
+                3
+        )                       
+        
+        k_resampled = jnp.fft.ifftshift(k_resampled, (-2, -1))
+
+        # conserve flux
+        
+        k_resampled = k_resampled * self._resolution_ratio
+
+        return k_resampled
+    
+
+class KConvolveRenderer(Renderer):
+    """
+    Convolve with obs PSF and return real image
+    """
+    def __init__(self, model_frame, obs_frame):
+        object.__setattr__(self, "_obs_shape", obs_frame.bbox.shape)
+
+        # get PSF from obs
+        psf = obs_frame.psf()
+        if len(psf.shape) == 2:  # only one image for all bands
+            # print("I am tiling the psf")
+            psf_model = jnp.tile(psf, (obs_frame.bbox.shape[0], 1, 1))
+        else:
+            psf_model = psf
+        object.__setattr__(self, "_psf_model", psf_model)
+
+        fft_out_shape = _get_fast_shape(obs_frame.bbox.shape, obs_frame.psf().shape, padding=300, axes=(-2, -1))
+        object.__setattr__(self, "_fft_out_shape", fft_out_shape)
+
+    def __call__(self, kimage, key=None):
+
+        # Convolve with obs PSF
+        # fft_shape = _get_fast_shape(model.shape, psf_model.shape, padding=3, axes=(-2, -1))
+
+        kpsf = transform(self._psf_model, self._fft_out_shape, (-2, -1))
+        # print("kimage.shape", kimage.shape)
+        # print("kpsf.shape", kpsf.shape)
+        kconv = kimage * kpsf
+
+        img = inverse(kconv, self._fft_out_shape, self._obs_shape, axes=(-2,-1))
+
+        return img

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -5,42 +5,48 @@ from .fft import convolve, deconvolve, _get_fast_shape
 
 
 class Renderer(eqx.Module):
+    def __call__(self, model, key=None):  # key is needed to chain renderers with eqx.nn.Sequential
+        raise NotImplementedError
+
+
+class NoRenderer(Renderer):
+    def __call__(self, model, key=None):
+        return model
+
+
+class ChannelRenderer(Renderer):
     channel_map: (None, list, slice) = None
 
     def __init__(self, model_frame, obs_frame):
-        self.channel_map = self.get_channel_map(model_frame, obs_frame)
-
-    def __call__(self, model):
-        raise NotImplementedError
-
-    def get_channel_map(self, model_frame, obs_frame):
         if obs_frame.channels == model_frame.channels:
-            return None
-        try:
-            channel_map = [
-                list(model_frame.channels).index(c) for c in list(obs_frame.channels)
-            ]
-        except ValueError:
-            msg = "Cannot match channels between model and observation.\n"
-            msg += f"Got {model_frame.channels} and {obs_frame.channels}."
-            raise ValueError(msg)
+            channel_map = None
+        else:
+            try:
+                channel_map = [
+                    list(model_frame.channels).index(c) for c in list(obs_frame.channels)
+                ]
+            except ValueError:
+                msg = "Cannot match channels between model and observation.\n"
+                msg += f"Got {model_frame.channels} and {obs_frame.channels}."
+                raise ValueError(msg)
 
-        min_channel = min(channel_map)
-        max_channel = max(channel_map)
-        if max_channel + 1 - min_channel == len(channel_map):
-            channel_map = slice(min_channel, max_channel + 1)
-        return channel_map
+            min_channel = min(channel_map)
+            max_channel = max(channel_map)
+            if max_channel + 1 - min_channel == len(channel_map):
+                channel_map = slice(min_channel, max_channel + 1)
+        self.channel_map = channel_map
 
-    def map_channels(self, model):
-        """Map to model channels onto the observation channels
-        Parameters
-        ----------
-        model: array
-            The hyperspectral model
-        Returns
-        -------
-        obs_model: array
-            `model` mapped onto the observation channels
+    def __call__(self, model, key=None):
+        """Map model channels onto the observation channels
+
+            Parameters
+            ----------
+            model: array
+                The hyperspectral model
+            Returns
+            -------
+            obs_model: array
+                `model` mapped onto the observation channels
         """
         if self.channel_map is None:
             return model
@@ -49,19 +55,8 @@ class Renderer(eqx.Module):
         # not yet used by any renderer: full matrix mapping between model and observation channels
         return jnp.dot(self.channel_map, model)
 
-
-class NoRenderer(Renderer):
-    def __init__(self):
-        self.channel_map = None
-
-    def __call__(self, model):
-        return model
-
-
 class ConvolutionRenderer(Renderer):
     def __init__(self, model_frame, obs_frame):
-        super().__init__(model_frame, obs_frame)
-
         # create PSF model
         psf = model_frame.psf()
         if len(psf.shape) == 2:  # only one image for all bands
@@ -74,7 +69,5 @@ class ConvolutionRenderer(Renderer):
         diff_kernel_fft = deconvolve(obs_frame.psf(), psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True)
         object.__setattr__(self, "_diff_kernel_fft", diff_kernel_fft)
 
-    def __call__(self, model):
-        # TODO: including slices
-        model_ = self.map_channels(model)
-        return convolve(model_, self._diff_kernel_fft, axes=(-2, -1))
+    def __call__(self, model, key=None):
+        return convolve(model, self._diff_kernel_fft, axes=(-2, -1))

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -6,8 +6,11 @@ from .fft import convolve, deconvolve, _get_fast_shape, transform, inverse
 
 from .interpolation import resample2d
 
+
 class Renderer(eqx.Module):
-    def __call__(self, model, key=None):  # key is needed to chain renderers with eqx.nn.Sequential
+    def __call__(
+        self, model, key=None
+    ):  # key is needed to chain renderers with eqx.nn.Sequential
         raise NotImplementedError
 
 
@@ -25,7 +28,8 @@ class ChannelRenderer(Renderer):
         else:
             try:
                 channel_map = [
-                    list(model_frame.channels).index(c) for c in list(obs_frame.channels)
+                    list(model_frame.channels).index(c)
+                    for c in list(obs_frame.channels)
                 ]
             except ValueError:
                 msg = "Cannot match channels between model and observation.\n"
@@ -41,14 +45,14 @@ class ChannelRenderer(Renderer):
     def __call__(self, model, key=None):
         """Map model channels onto the observation channels
 
-            Parameters
-            ----------
-            model: array
-                The hyperspectral model
-            Returns
-            -------
-            obs_model: array
-                `model` mapped onto the observation channels
+        Parameters
+        ----------
+        model: array
+            The hyperspectral model
+        Returns
+        -------
+        obs_model: array
+            `model` mapped onto the observation channels
         """
         if self.channel_map is None:
             return model
@@ -56,6 +60,7 @@ class ChannelRenderer(Renderer):
             return model[self.channel_map, :, :]
         # not yet used by any renderer: full matrix mapping between model and observation channels
         return jnp.dot(self.channel_map, model)
+
 
 class ConvolutionRenderer(Renderer):
     def __init__(self, model_frame, obs_frame):
@@ -66,121 +71,129 @@ class ConvolutionRenderer(Renderer):
         else:
             psf_model = psf
         # make sure fft uses a shape large enough to cover the convolved model
-        fft_shape = _get_fast_shape(model_frame.bbox.shape, psf_model.shape, padding=3, axes=(-2, -1))
+        fft_shape = _get_fast_shape(
+            model_frame.bbox.shape, psf_model.shape, padding=3, axes=(-2, -1)
+        )
 
         # compute and store diff kernel in Fourier space
-        diff_kernel_fft = deconvolve(obs_frame.psf(), psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True)
+        diff_kernel_fft = deconvolve(
+            obs_frame.psf(),
+            psf_model,
+            axes=(-2, -1),
+            fft_shape=fft_shape,
+            return_fft=True,
+        )
         object.__setattr__(self, "_diff_kernel_fft", diff_kernel_fft)
 
     def __call__(self, model, key=None):
         return convolve(model, self._diff_kernel_fft, axes=(-2, -1))
+
 
 class KDeconvRenderer(Renderer):
     """
     Perform decovolution in Fourier space and return the Fourier decovolved
     model
     """
+
     def __init__(self, model_frame, obs_frame):
         # create PSF model
         psf = model_frame.psf()
         if len(psf.shape) == 2:  # only one image for all bands
-            # print("I am tiling the psf")
             psf_model = jnp.tile(psf, (model_frame.bbox.shape[0], 1, 1))
         else:
             psf_model = psf
         object.__setattr__(self, "_psf_model", psf_model)
 
     def __call__(self, model, key=None):
-        # print(model)
         psf_model = self._psf_model
-        # print(model.shape)
-        # print(psf_model.shape)
-        fft_shape = _get_fast_shape(model.shape, psf_model.shape, padding=1000, axes=(-2, -1))
-        print()
-        deconv_ = deconvolve(model, psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True)
-        # print(deconv_.dtype)
+        fft_shape = _get_fast_shape(
+            model.shape, psf_model.shape, padding=1000, axes=(-2, -1)
+        )
+        deconv_ = deconvolve(
+            model, psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True
+        )
+
         return deconv_
+
 
 class KResampleRenderer(Renderer):
     """
     Perform resampling in Fourier space
-    
+
     Should get as input a Fourier image sampled at the model frame resolution
     Needs to return a Fourier image sampled at the observation frame resolution
-    """ 
-    def __init__(self, model_frame, obs_frame): 
+    """
+
+    def __init__(self, model_frame, obs_frame):
         object.__setattr__(self, "_in_res", model_frame.pixel_size)
         object.__setattr__(self, "_out_res", obs_frame.pixel_size)
 
         # find on what grid we will interpolate
-        fft_out_shape = _get_fast_shape(obs_frame.bbox.shape, obs_frame.psf().shape, padding=300, axes=(-2, -1))
+        fft_out_shape = _get_fast_shape(
+            obs_frame.bbox.shape, obs_frame.psf().shape, padding=300, axes=(-2, -1)
+        )
         object.__setattr__(self, "_fft_out_shape", fft_out_shape)
 
         # compute resolution ratio for flux conservation
-        object.__setattr__(self, "_resolution_ratio", obs_frame.pixel_size/model_frame.pixel_size)
-
+        object.__setattr__(
+            self, "_resolution_ratio", obs_frame.pixel_size / model_frame.pixel_size
+        )
 
     def __call__(self, kimage, key=None):
 
         # compute model k-coordinates of the fourier input image
-        ky_in = jnp.linspace(-.5, .5, kimage.shape[1]) / self._in_res
-        kx_in = jnp.linspace(0, .5, kimage.shape[1]//2+1) / self._in_res
+        ky_in = jnp.linspace(-0.5, 0.5, kimage.shape[1]) / self._in_res
+        kx_in = jnp.linspace(0, 0.5, kimage.shape[1] // 2 + 1) / self._in_res
 
-        ky_out = jnp.linspace(-.5, .5, self._fft_out_shape[0]) / self._out_res
-        kx_out = jnp.linspace(0, .5, self._fft_out_shape[0]//2+1) / self._out_res
-        
+        ky_out = jnp.linspace(-0.5, 0.5, self._fft_out_shape[0]) / self._out_res
+        kx_out = jnp.linspace(0, 0.5, self._fft_out_shape[0] // 2 + 1) / self._out_res
+
         kimage = jnp.fft.fftshift(kimage, -2)
 
         kcoords_in = jnp.stack(jnp.meshgrid(kx_in, ky_in), -1)
         kcoords_out = jnp.stack(jnp.meshgrid(kx_out, ky_out), -1)
-        
-        # import jii
-        k_resampled = jax.vmap(
-            resample2d,
-            in_axes=(0, None, None, None))(
-                kimage,
-                kcoords_in,
-                kcoords_out,
-                3
-        )                       
-        
+
+        k_resampled = jax.vmap(resample2d, in_axes=(0, None, None, None))(
+            kimage, kcoords_in, kcoords_out, 3
+        )
+
         k_resampled = jnp.fft.ifftshift(k_resampled, -2)
 
         # conserve flux
         k_resampled = k_resampled * self._resolution_ratio
 
         return k_resampled
-    
+
 
 class KConvolveRenderer(Renderer):
     """
     Convolve with obs PSF and return real image
     """
+
     def __init__(self, model_frame, obs_frame):
         object.__setattr__(self, "_obs_shape", obs_frame.bbox.shape)
 
         # get PSF from obs
         psf = obs_frame.psf()
         if len(psf.shape) == 2:  # only one image for all bands
-            # print("I am tiling the psf")
             psf_model = jnp.tile(psf, (obs_frame.bbox.shape[0], 1, 1))
         else:
             psf_model = psf
         object.__setattr__(self, "_psf_model", psf_model)
 
-        fft_out_shape = _get_fast_shape(obs_frame.bbox.shape, obs_frame.psf().shape, padding=300, axes=(-2, -1))
+        fft_out_shape = _get_fast_shape(
+            obs_frame.bbox.shape, obs_frame.psf().shape, padding=300, axes=(-2, -1)
+        )
         object.__setattr__(self, "_fft_out_shape", fft_out_shape)
 
     def __call__(self, kimage, key=None):
 
         # Convolve with obs PSF
-        # fft_shape = _get_fast_shape(model.shape, psf_model.shape, padding=3, axes=(-2, -1))
 
         kpsf = transform(self._psf_model, self._fft_out_shape, (-2, -1))
-        # print("kimage.shape", kimage.shape)
-        # print("kpsf.shape", kpsf.shape)
+
         kconv = kimage * kpsf
 
-        img = inverse(kconv, self._fft_out_shape, self._obs_shape, axes=(-2,-1))
+        img = inverse(kconv, self._fft_out_shape, self._obs_shape, axes=(-2, -1))
 
         return img

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=['scarlet2'],
     install_requires=[
         'equinox',
+        'jax',
         'astropy',
         'numpy',
         'matplotlib'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup(
+    name='scarlet2',
+    version='0.1.0',    
+    description='Scarlet, all new and shiny',
+    url='https://github.com/pmelchior/scarlet2',
+    author='Peter Melchior',
+    author_email='melchior@astro.princeton.edu',
+    license='MIT',
+    packages=['scarlet2'],
+    install_requires=[
+        'equinox',
+        'astropy',
+        'numpy',
+        'matplotlib'
+    ],
+)


### PR DESCRIPTION
This PR enables resampling a model frame to an observation frame with a Lanczos kernel. More precisely, here is what is added from the current main version:
- [x] channel renderer (collapse channels that are not needed)
- [x] Modular deconvolution/resampling/convolution renderers
- [x] `interpolation.py`, with lanczcos image resampling
- [x] 4 times image padding (as advised in [Bernstein & Gruen (2014)](https://arxiv.org/abs/1401.2636))
- [x] switch (if it's the same  `pixel_size`, use the already existing `ConvolutionRenderer`)

In addition, I have added
- [x] a `setup.py` for pip install
- [x] frame generator from observations ([from scarlet](https://github.com/pmelchior/scarlet/blob/45187fdccbe8b8c8d7551a84572d7243b24bc8cb/scarlet/frame.py#L156), this was not needed but useful for my tests)

For a quick demo of HST to HSC resampling, you can run this notebook https://colab.research.google.com/drive/1aA-ynB0BZiD7hL2PhrbHFyvxzRCC7CgY?usp=sharing

Let me know your thought and I you want me to add anything!

I am leaving this PR as a draft today because I couldn't figure out a way to jit `obs.render` and wanted to get your feedback to enable the feature. Have you tried this before @pmelchior @SampsonML @charlotteaward  @jaredcsiegel ?