### PR TITLE
Combined sources

### DIFF
--- a/scarlet2/__init__.py
+++ b/scarlet2/__init__.py
@@ -6,5 +6,5 @@ from .morphology import Morphology, ArrayMorphology, GaussianMorphology
 from .observation import Observation
 from .psf import PSF, ArrayPSF, GaussianPSF
 from .scene import Scene
-from .source import Source, PointSource
+from .source import Component, DustComponent, Source, PointSource
 from .spectrum import Spectrum, ArraySpectrum, StaticArraySpectrum, TransientArraySpectrum

--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -9,7 +9,6 @@ from .psf import PSF
 
 class Frame(eqx.Module):
     bbox: Box
-    pixel_size: jnp.ndarray
     psf: PSF = None
     wcs: astropy.wcs.wcs = None
     channels: list
@@ -18,7 +17,6 @@ class Frame(eqx.Module):
         self.bbox = bbox
         self.psf = psf
         self.wcs = wcs
-        self.pixel_size = get_pixel_size(get_affine(self.wcs)) * 60 * 60  # in arcsec
         if channels is None:
             channels = list(range(bbox.shape[0]))
         assert len(channels) == bbox.shape[0]
@@ -27,6 +25,13 @@ class Frame(eqx.Module):
 
     def __hash__(self):
         return hash(self.bbox)
+
+    @property
+    def pixel_size(self):
+        if self.wcs is not None:
+            return get_pixel_size(get_affine(self.wcs)) * 60 * 60  # in arcsec
+        else:
+            return 1
 
     def get_pixel(self, sky_coord):
         """Get the pixel coordinate from a world coordinate

--- a/scarlet2/module.py
+++ b/scarlet2/module.py
@@ -119,10 +119,16 @@ class Module(eqx.Module):
                     get_info(name_, p, infodict)
             elif isinstance(a, (list, tuple)):
                 for i, a_ in enumerate(a):
-                    params_ = a_.get_parameters(return_info=True, list_fixed=list_fixed)
-                    for k, (p, infodict) in params_.items():
-                        name_ = f"{name}.{i}.{k}"
-                        get_info(name_, p, infodict)
+                    try:
+                        params_ = a_.get_parameters(return_info=True, list_fixed=list_fixed)
+                        for k, (p, infodict) in params_.items():
+                            name_ = f"{name}.{i}.{k}"
+                            get_info(name_, p, infodict)
+                    except AttributeError:
+                        pass
+            else:
+                continue
+
         if return_value:
             if return_info:
                 params = {k: (params[k], info[k]) for k in params.keys()}

--- a/scarlet2/source.py
+++ b/scarlet2/source.py
@@ -1,6 +1,7 @@
 import copy
 import operator
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 
@@ -37,12 +38,14 @@ class DustComponent(Component):
 
 class Source(Component):
     components: list
+    component_ops: list = eqx.field(static=True)
 
     def __init__(self, center, spectrum, morphology):
         # set the base component
         super().__init__(center, spectrum, morphology)
         # create the empty component list
         self.components = list()
+        self.component_ops = list()
 
         # add this source to the active scene
         try:
@@ -66,9 +69,11 @@ class Source(Component):
                 raise
             except ValueError:
                 pass
+
         # adding a full source will maintain its ownership of components:
         # hierarchical definition of sources withing sources
-        self.components.append((component, op))
+        self.components.append(component)
+        self.component_ops.append(op)
         return self
 
     def __iadd__(self, component):
@@ -80,7 +85,7 @@ class Source(Component):
     def __call__(self):
         base = super()
         model = base.__call__()
-        for component, op in self.components:
+        for component, op in zip(self.components, self.component_ops):
             model_ = component()
             # cut out regions from model and model_
             bbox, bbox_ = overlap_slices(base.bbox, component.bbox, return_boxes=True)

--- a/scarlet2/source.py
+++ b/scarlet2/source.py
@@ -69,12 +69,13 @@ class Source(Component):
         # adding a full source will maintain its ownership of components:
         # hierarchical definition of sources withing sources
         self.components.append((component, op))
+        return self
 
     def __iadd__(self, component):
-        self.add_component(component, operator.add)
+        return self.add_component(component, operator.add)
 
     def __imul__(self, component):
-        self.add_component(component, operator.mul)
+        return self.add_component(component, operator.mul)
 
     def __call__(self):
         base = super()

--- a/scarlet2/source.py
+++ b/scarlet2/source.py
@@ -1,12 +1,17 @@
 import copy
+import operator
 
+import jax
+import jax.numpy as jnp
+
+from .bbox import overlap_slices
 from .module import Module
 from .morphology import Morphology
 from .scene import Scenery
 from .spectrum import Spectrum
 
 
-class Source(Module):
+class Component(Module):
     spectrum: Spectrum
     morphology: Morphology
 
@@ -16,6 +21,29 @@ class Source(Module):
         self.morphology.center_bbox(center)
         super().__post_init__()
 
+    def __call__(self):
+        # Boxed model
+        return self.spectrum()[:, None, None] * self.morphology()[None, :, :]
+
+    @property
+    def bbox(self):
+        return self.spectrum.bbox @ self.morphology.bbox
+
+
+class DustComponent(Component):
+    def __call__(self):
+        return jnp.exp(-super().__call__())
+
+
+class Source(Component):
+    components: list
+
+    def __init__(self, center, spectrum, morphology):
+        # set the base component
+        super().__init__(center, spectrum, morphology)
+        # create the empty component list
+        self.components = list()
+
         # add this source to the active scene
         try:
             Scenery.scene.sources.append(self)
@@ -24,13 +52,45 @@ class Source(Module):
             print("Use 'with Scene(frame) as scene: Source(...)'")
             raise
 
-    def __call__(self):
-        # Boxed model
-        return self.spectrum()[:, None, None] * self.morphology()[None, :, :]
+    def add_component(self, component, op):
+        assert isinstance(component, (Source, Component))
 
-    @property
-    def bbox(self):
-        return self.spectrum.bbox @ self.morphology.bbox
+        # if component is a source, it's already registered in scene
+        # remove it from scene to not call it twice
+        if isinstance(component, Source):
+            try:
+                Scenery.scene.sources.remove(component)
+            except AttributeError:
+                print("Source can only be modified within the context of a Scene")
+                print("Use 'with Scene(frame) as scene: Source(...)'")
+                raise
+            except ValueError:
+                pass
+        # adding a full source will maintain its ownership of components:
+        # hierarchical definition of sources withing sources
+        self.components.append((component, op))
+
+    def __iadd__(self, component):
+        self.add_component(component, operator.add)
+
+    def __imul__(self, component):
+        self.add_component(component, operator.mul)
+
+    def __call__(self):
+        base = super()
+        model = base.__call__()
+        for component, op in self.components:
+            model_ = component()
+            # cut out regions from model and model_
+            bbox, bbox_ = overlap_slices(base.bbox, component.bbox, return_boxes=True)
+            sub_model = jax.lax.dynamic_slice(model, bbox.start, bbox.shape)
+            sub_model_ = jax.lax.dynamic_slice(model_, bbox_.start, bbox_.shape)
+            # combine with operator
+            sub_model = op(sub_model, sub_model_)
+            # add model_ back in full model
+            model = jax.lax.dynamic_update_slice(model, sub_model, bbox.start)
+        return model
+
 
 class PointSource(Source):
     def __init__(self, center, spectrum):


### PR DESCRIPTION
This PR brings sources with more than one component. The idea is that a source gets a new attribute: `components`, which behave like sources themselves. These can be added or multiplied to the existing source, e.g. a bulge component

```python
source = Source(center, spectrum, morphology)
bulge = Component(center, bulge_spectrum, bulge_morphology)
source += bulge
```

or a dust component
```python
source = Source(center, spectrum, morphology)
dust = DustComponent(center, dust_spectrum, dust_morphology)
source *= dust
```

The difference between `Source` and `Component` is as follows:
1. A `Source` _is_ a `Component`
2. A `Source` _can have_ additional `Component` or `Source` instances, that are added/multiplied on top of itself in the order they have been pushed onto the `components` list
3. A `Scene` only registers `Source`s: as the name implies, sources shine, while components themselves do not.

Item 1 states that the modeling implementation rests with `Component`. This is why we have a `DustComponent` because it needs a `__call__` that returns $\exp(-\mathrm{spectrum}\times\mathrm{morphology})$.

Item 2 states that you can also add sources to sources to make them fully hierarchical. This might be good for organizing sources, but it's critical if we want different pieces of a galaxy to have different dust attenuation.

Item 3 prevents nonsensical behavior, e.g. to have a `DustComponent` without its base `Source` (it can't attenuate if it doesn't get illuminated) or to evaluate a `Component` twice, namely on its own and then as component of a source. 