### PR TITLE
Profile morphology from ellipticities

### DIFF
--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -102,7 +102,7 @@ class GaussianMorphology(ProfileMorphology):
     def __call__(self):
 
         # faster circular 2D Gaussian: instead of N^2 evaluations, use outer product of 2 1D Gaussian evals
-        if self.ellipticity==jnp.zeros((2,)):
+        if (self.ellipticity==jnp.zeros((2,))).all():
 
             _Y = jnp.arange(self.bbox.shape[-2]) + self.bbox.origin[-2] - self.center[-2]
             _X = jnp.arange(self.bbox.shape[-1]) + self.bbox.origin[-1] - self.center[-1]

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -37,12 +37,18 @@ class ProfileMorphology(Morphology):
     center: jnp.array
     size: float
     ellipticity: (None, jnp.array)
+    g: (None, jnp.array)
 
     def __init__(self, center, size, ellipticity=None, bbox=None):
 
         # define radial profile function
         self.center = center
         self.size = size
+        self.ellipticity = ellipticity
+
+        g_factor = 1 / (1. + jnp.sqrt(1. - (ellipticity[0]**2 + ellipticity[1]**2)))
+        self.g = self.ellipticity * g_factor
+
         self.ellipticity = ellipticity
         super().__post_init__()
 
@@ -69,12 +75,13 @@ class ProfileMorphology(Morphology):
         if self.ellipticity is None:
             R2 = _Y[:, None] ** 2 + _X[None, :] ** 2
         else:
-            e1, e2 = self.ellipticity
-            __X = ((1 - e1) * _X[None, :] - e2 * _Y[:, None]) / jnp.sqrt(
-                1 - (e1 ** 2 + e2 ** 2)
+
+            g1, g2 = self.g
+            __X = ((1 - g1) * _X[None, :] - g2 * _Y[:, None]) / jnp.sqrt(
+                1 - (g1 ** 2 + g2 ** 2)
             )
-            __Y = (-e2 * _X[None, :] + (1 + e1) * _Y[:, None]) / jnp.sqrt(
-                1 - (e1 ** 2 + e2 ** 2)
+            __Y = (-g2 * _X[None, :] + (1 + g1) * _Y[:, None]) / jnp.sqrt(
+                1 - (g1 ** 2 + g2 ** 2)
             )
             R2 = __Y ** 2 + __X ** 2
 


### PR DESCRIPTION
Hi @SampsonML , @pmelchior ,

I think I found the issue with generating `ProfileMorphology` from ellipticities. 

The coordinate transformation matrix
$` \dfrac{1}{\sqrt{1-g²}} \begin{pmatrix} 1+g_1 & g_2 \\ g_2 & 1-g_1 \end{pmatrix}`$ (the covariance matrix is the inverse of this one), 

is defined with respect to $`g`$ which is the *reduced* definition of the ellipticity. However, the input parameters of the profile are $`e_1`$ and $`e_2`$ which are the *distortion* definition ([see here](https://galsim-developers.github.io/GalSim/_build/html/shear.html) for definitions and how to convert one from the other).

I am fine working with $`e_1`$ and $`e_2`$ and this is what is computed using the moments in [Melchior et al. (2010)](https://academic.oup.com/mnras/article/412/3/1552/1050244?login=false) eq. 2:

$\epsilon = [G_{20} - G_{02} + 2iG_{11}] / [G_{20} + G_{02}]$.

I am not familiar with the formula in #47 using an additional term in the denominator, and everything is consistent with the definition above.

Therefore, I think the `moments` method in `measure.py` is correct, we just need to make a conversion when using distortion ellipticities in `morphology.py` (hence this PR). For later, we may want to have the flexibility to take as input either distortion or reduced ellipticities, let me know if you want me to add these options.

[Here is a notebook](https://colab.research.google.com/drive/1cS6YnQNI0OyIPGIctQoLSQx33PG-ak4C?usp=sharing) which compares the two definitions (for ellipticity computation) and where the profile is generated using the conversion from distortion to reduced ellipticities.