### PR TITLE
Update multiresolution renderer and test

### DIFF
--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -63,12 +63,12 @@ class Quintic(Interpolant):
         """
         u = jnp.abs(u)
         s = jnp.sinc(u)
-        piu = jnp.pi * u
+        piu = jnp.pi*u
         c = jnp.cos(piu)
-        ssq = s * s
-        piusq = piu * piu
+        ssq = s*s
+        piusq = piu*piu
         
-        return s * ssq * ssq * (s * (55.0 - 19.0 * piusq) + 2.0 * c * (piusq - 27.0))
+        return s * ssq * ssq * (s * (55. - 19. * piusq) + 2. * c * (piusq - 27.))
 
 ### Lanczos interpolant
 

--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -2,6 +2,11 @@ import jax
 import jax.numpy as jnp
 import equinox as eqx
 
+"""
+Some of the code to perform interpolation in Fourier space as been adapted from
+https://github.com/GalSim-developers/JAX-GalSim/blob/main/jax_galsim/interpolant.py
+https://github.com/GalSim-developers/JAX-GalSim/blob/main/jax_galsim/interpolatedimage.py
+"""
 
 ### Interpolant class
 
@@ -13,88 +18,108 @@ class Interpolant(eqx.Module):
 
     def kernel(self, x):
         raise NotImplementedError
+    
+    def uval(self, u):
+        raise NotImplementedError
 
 ### Quintic interpolant
 
-def f_0_1_q(x):
-    return 1 + x*x*x * (-95 + 138*x - 55*x*x) / 12
-
-def f_1_2_q(x):
-    return (x-1)*(x-2) * (-138 + 348*x - 249*x*x + 55*x*x*x) / 24
-
-
-def f_2_3_q(x):
-    return (x-2)*(x-3)*(x-3)*(-54 + 50*x - 11*x*x) / 24
-
-def f_3_q(x):
-    return jnp.zeros_like(x, dtype=x.dtype)
-
-def quintic(x):
-    x = jnp.abs(x) # quitic kernel is even
-
-    b1 = x <= 1
-    b2 = x <= 2
-    b3 = x <= 3 
-
-    return jnp.piecewise(
-        x, 
-        [b1, (~b1) & b2, (~b2) & b3], 
-        [f_0_1_q, f_1_2_q, f_2_3_q, f_3_q]
-        )
-
-class Quntic(Interpolant):
+class Quintic(Interpolant):
     def __init__(self):
         self.extent = 3
-    
+
+    def f_0_1_q(self, x):
+        return 1 + x*x*x * (-95 + 138*x - 55*x*x) / 12
+
+    def f_1_2_q(self, x):
+        return (x-1)*(x-2) * (-138 + 348*x - 249*x*x + 55*x*x*x) / 24
+
+
+    def f_2_3_q(self, x):
+        return (x-2)*(x-3)*(x-3)*(-54 + 50*x - 11*x*x) / 24
+
+    def f_3_q(self, x):
+        return jnp.zeros_like(x, dtype=x.dtype)
+
     def kernel(self, x):
-        return quintic(x)
+        """
+        Quintic kernel values in direct space
+        """
+        x = jnp.abs(x) # quitic kernel is even
+
+        b1 = x <= 1
+        b2 = x <= 2
+        b3 = x <= 3 
+
+        return jnp.piecewise(
+            x, 
+            [b1, (~b1) & b2, (~b2) & b3], 
+            [self.f_0_1_q, self.f_1_2_q, self.f_2_3_q, self.f_3_q]
+            )
+    
+    def uval(self, u):
+        """
+        Quintic kernel values in Fourier space
+        """
+        u = jnp.abs(u)
+        s = jnp.sinc(u)
+        piu = jnp.pi * u
+        c = jnp.cos(piu)
+        ssq = s * s
+        piusq = piu * piu
+        
+        return s * ssq * ssq * (s * (55.0 - 19.0 * piusq) + 2.0 * c * (piusq - 27.0))
 
 ### Lanczos interpolant
 
-def f_1(x, n):
-    """
-    Approximation from galsim
-    // res = n/(pi x)^2 * sin(pi x) * sin(pi x / n)
-    //     ~= (1 - 1/6 pix^2) * (1 - 1/6 pix^2 / n^2)
-    //     = 1 - 1/6 pix^2 ( 1 + 1/n^2 )
-    """
-    px = jnp.pi * x
-    temp = 1./6. * px * px
-    res = 1. - temp * (1. + 1. / (n * n))
-    return res
-
-
-def f_2(x, n):
-    px = jnp.pi * x
-    return n * jnp.sin(px) * jnp.sin(px / n) / px / px
-
-def lanczos_n(x, n=3):
-    """
-    Lanczos interpolation kernel
-
-    Parameters
-    ----------
-    n: Lanczos order
-    """
-    small_x = jnp.abs(x) <= 1e-4
-    window_n = jnp.abs(x) <= n
-
-    return jnp.piecewise(
-        x, 
-        [small_x, (~small_x) & window_n], 
-        [f_1, f_2, lambda x, n: jnp.array(0)], n
-    )
-
 class Lanczos(Interpolant):
+    
     def __init__(self, n):
+        """
+        Lanczos interpolant
+
+        Parameters
+        ----------
+        n: Lanczos order
+        """
+
         self.extent = n
     
+    def f_1(x, n):
+        """
+        Approximation from galsim
+        // res = n/(pi x)^2 * sin(pi x) * sin(pi x / n)
+        //     ~= (1 - 1/6 pix^2) * (1 - 1/6 pix^2 / n^2)
+        //     = 1 - 1/6 pix^2 ( 1 + 1/n^2 )
+        """
+        px = jnp.pi * x
+        temp = 1./6. * px * px
+        res = 1. - temp * (1. + 1. / (n * n))
+        return res
+
+    def f_2(x, n):
+        px = jnp.pi * x
+        return n * jnp.sin(px) * jnp.sin(px / n) / px / px
+
+    def lanczos_n(x, n=3):
+        """
+        Lanczos interpolation kernel in direct space
+        """
+        small_x = jnp.abs(x) <= 1e-4
+        window_n = jnp.abs(x) <= n
+
+        return jnp.piecewise(
+            x, 
+            [small_x, (~small_x) & window_n], 
+            [f_1, f_2, lambda x, n: jnp.array(0)], n
+        )
+
     def kernel(self, x):
-        return lanczos_n(x, self.extent)
+        return self.lanczos_n(x, self.extent)
 
 ### Resampling function
 
-def resample2d(signal, coords, warp, interpolant=Lanczos(3)):
+def resample2d(signal, coords, warp, interpolant=Quintic()):
     """
     Resample a 2-dimensional image using a Lanczos kernel
 
@@ -122,9 +147,6 @@ def resample2d(signal, coords, warp, interpolant=Lanczos(3)):
     resampled_signal: array
     """
 
-    print("interpolant", interpolant)
-    print(interpolant.extent)
-
     x = warp[..., 0].flatten()
     y = warp[..., 1].flatten()
 
@@ -145,8 +167,6 @@ def resample2d(signal, coords, warp, interpolant=Lanczos(3)):
         xind = xi + i
         maskx = (xind >= 0) & (xind < Ny)
 
-        # kx = quintic((x - coords_x[xind]) / h)
-        # kx = lanczos_n((x - coords_x[xind]) / h, n)
         kx = interpolant.kernel((x - coords_x[xind]) / h)
 
         k = kx * ky
@@ -161,8 +181,6 @@ def resample2d(signal, coords, warp, interpolant=Lanczos(3)):
         yind = yi + i
         masky = (yind >= 0) & (yind < Nx)
 
-        # ky = quintic((y - coords_y[yind]) / h)
-        # ky = lanczos_n((y - coords_y[yind]) / h, n)
         ky = interpolant.kernel((y - coords_y[yind]) / h)
 
         res = jax.lax.fori_loop(-interpolant.extent, interpolant.extent + 1, body_fun_x, (res, yind, ky, masky))[0]
@@ -174,3 +192,105 @@ def resample2d(signal, coords, warp, interpolant=Lanczos(3)):
     )
 
     return res.reshape(warp[..., 0].shape)
+
+def resample_hermitian(signal, warp, x_min, y_min, interpolant=Quintic()):
+    """
+    Resample a 2-dimensional image using a Lanczos kernel
+    This is assuming that the signal is Hermitian and starting at 0 on axis=2,
+    i.e. f(-x, -y) = conjugate(f(x, y))
+
+    Parameters
+    ----------
+    signal: array
+        2d array containing the signal. We assume here that the coordinates of
+        the signal
+        shape: [Nx, Ny]
+    warp: array
+        Coordinates on which to resample the signal, in the grid of signal
+        coordinates [[0 ... signal.shape[0]], [0 ... signal.shape[1]]
+        shape:[nx, ny, 2]
+        [ [[0,  0], [0,  1], ...,  [0,  N-1]],
+                           [ ... ],
+          [[N-1,0], [N-1,1], ...,  [N-1,N  ]] ]
+    n: Lanczos order
+
+    Returns
+    -------
+    resampled_signal: array
+    """
+
+    x = warp[..., 0].flatten()
+    y = warp[..., 1].flatten()
+
+    xi = jnp.floor(x-x_min).astype(jnp.int32)
+    yi = jnp.floor(y-y_min).astype(jnp.int32)
+
+    xp = xi + x_min
+    yp = yi + y_min
+
+    nkx_2 = signal.shape[1]-1
+    nkx = signal.shape[0]
+
+    def body_fun_x(i, args):
+        res, yind, ky = args
+
+        xind = (xi + i) % nkx
+        
+        kx = interpolant.kernel(x - (xp+i))
+
+        k = kx * ky
+        
+        tmp = jnp.where(xind < nkx_2,
+                        signal[(nkx - yind) % nkx, nkx - xind - nkx_2].conjugate(),
+                        signal[yind, xind - nkx_2]
+                        )
+        
+        res += tmp * k
+
+        return res, yind, ky
+
+    def body_fun_y(i, args):
+        res = args
+
+        yind = yi + i
+
+        ky = interpolant.kernel(y - (yp+i))
+
+        res = jax.lax.fori_loop(-interpolant.extent, interpolant.extent + 1, body_fun_x, (res, yind, ky))[0]
+
+        return res
+
+    res = jax.lax.fori_loop(
+        -interpolant.extent, interpolant.extent + 1, body_fun_y, jnp.zeros_like(x).astype(signal.dtype)
+    )
+
+    return res.reshape(warp[..., 0].shape)
+
+def resample_ops(kimage, shape_in, shape_out, res_in, res_out, interpolant=Quintic()):
+    """
+    Resampling operation used in the Multiresolution Renderers
+    This is assuming that the signal is Hermitian and starting at 0 on axis=2,
+    i.e. f(-x, -y) = conjugate(f(x, y))
+    """
+    kcoords_out = jnp.stack(jnp.meshgrid(
+        jnp.linspace(0, shape_in/2 / res_out*res_in, shape_out//2+1),
+        jnp.linspace(-shape_in/2/res_out*res_in, shape_in/2/res_out*res_in, shape_out)
+        ),
+        -1)
+    
+    k_resampled = jax.vmap(resample_hermitian, in_axes=(0,None,None,None,None))(
+        kimage,
+        kcoords_out,
+        -shape_in/2,
+        -shape_in/2,
+        interpolant
+        )
+    
+
+    kx = jnp.linspace(0, jnp.pi, shape_out//2 + 1) * res_in/res_out
+    ky = jnp.linspace(-jnp.pi, jnp.pi, shape_out)
+    coords = jnp.stack(jnp.meshgrid(kx, ky),-1) / 2 / jnp.pi
+
+    xint_val = interpolant.uval(coords[...,0]) * interpolant.uval(coords[...,1])
+    
+    return k_resampled * jnp.expand_dims(xint_val, 0)

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -65,10 +65,11 @@ class Observation(Module):
 
             if self.frame.psf != frame.psf:
                 if frame.pixel_size != self.frame.pixel_size:
-                    # 2) Deconvolve with the model PSF, returns Fourier space image
+                    # 2) Pad model, model psf and obs psf and Fourier transform
                     renderers.append(PreprocessMultiresRenderer(frame, self.frame))
 
-                    # 3)a) Resample at the obs resolution
+                    # 3)a) Resample at the obs resolution, deconvolve model PSF and
+                    # convolve with obs PSF in Fourier space
                     renderers.append(ResamplingMultiresRenderer(frame, self.frame))
 
                     # 3)b) TODO: rotate and resample to obs orientation
@@ -76,14 +77,14 @@ class Observation(Module):
                     # same_res = abs(h - 1) < np.finfo(float).eps
                     # same_rot = (np.abs(angle[1]) ** 2) < np.finfo(float).eps
 
-                    # # 4) convolve with obs PSF
+                    # # convolve with obs PSF
                     # # TODO: if 2) is a resampling operation: model PSF needs to be resampled accordingly
                     # # Can be done by passing the renderer up to here to ConvolutionRenderer constructor below
                     # # Alternative: deconvolve from model_psf before 2) and convolve with full PSF in 3)
                     # # which is more modular but also more expensive unless all operations remain in Fourier space
 
-                    # Convolve with obs PSF and return real image
-                    renderers.append(PostprocessMultiresRenderer())
+                    # 4) Wrap the Fourier image and crop to obs frame
+                    renderers.append(PostprocessMultiresRenderer(frame, self.frame))
 
                 else:
                     renderers.append(ConvolutionRenderer(frame, self.frame))

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -9,9 +9,9 @@ from .renderer import (
     NoRenderer,
     ConvolutionRenderer,
     ChannelRenderer,
-    KDeconvRenderer,
-    KResampleRenderer,
-    KConvolveRenderer,
+    PreprocessMultiresRenderer,
+    ResamplingMultiresRenderer,
+    PostprocessMultiresRenderer
 )
 
 
@@ -66,10 +66,10 @@ class Observation(Module):
             if self.frame.psf != frame.psf:
                 if frame.pixel_size != self.frame.pixel_size:
                     # 2) Deconvolve with the model PSF, returns Fourier space image
-                    renderers.append(KDeconvRenderer(frame))
+                    renderers.append(PreprocessMultiresRenderer(frame, self.frame))
 
                     # 3)a) Resample at the obs resolution
-                    renderers.append(KResampleRenderer(frame, self.frame))
+                    renderers.append(ResamplingMultiresRenderer(frame, self.frame))
 
                     # 3)b) TODO: rotate and resample to obs orientation
                     # angle, h = interpolation.get_angles(self.wcs, frame.wcs)
@@ -83,7 +83,7 @@ class Observation(Module):
                     # # which is more modular but also more expensive unless all operations remain in Fourier space
 
                     # Convolve with obs PSF and return real image
-                    renderers.append(KConvolveRenderer(self.frame))
+                    renderers.append(PostprocessMultiresRenderer())
 
                 else:
                     renderers.append(ConvolutionRenderer(frame, self.frame))

--- a/scarlet2/psf.py
+++ b/scarlet2/psf.py
@@ -12,7 +12,7 @@ class ArrayPSF(PSF):
     morphology: jnp.ndarray
 
     def __call__(self):
-        return self.morphology / self.morphology.sum()
+        return self.morphology / self.morphology.sum((-2,-1), keepdims=True)
 
 
 class GaussianPSF(PSF):
@@ -24,5 +24,5 @@ class GaussianPSF(PSF):
 
     def __call__(self):
         morph = self.morphology()
-        morph /= morph.sum()
+        morph /= morph.sum((-2,-1), keepdims=True)
         return morph

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -174,7 +174,7 @@ class KResampleRenderer(Renderer):
         k_resampled = jnp.fft.ifftshift(k_resampled, -2)
 
         # conserve flux
-        k_resampled = k_resampled * self._resolution_ratio
+        k_resampled = k_resampled
 
         return k_resampled
 

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -2,9 +2,9 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax
 
-from .fft import convolve, deconvolve, _get_fast_shape, transform, inverse, good_fft_size, _pad, _trim
+from .fft import convolve, deconvolve, _get_fast_shape, transform, good_fft_size, _trim
 
-from .interpolation import resample_ops, Quintic
+from .interpolation import resample_ops
 
 from .fft import wrap_hermitian_x
 
@@ -89,194 +89,6 @@ class ConvolutionRenderer(Renderer):
 
     def __call__(self, model, key=None):
         return convolve(model, self._diff_kernel_fft, axes=(-2, -1))
-
-
-class KDeconvRenderer(Renderer):
-    """
-    Perform decovolution in Fourier space and return the Fourier decovolved
-    model
-    """
-
-    def __init__(self, model_frame, padding=None):
-
-        if padding == None:
-            # use 4 times padding
-            padding = 4
-        object.__setattr__(self, "_padding", padding)
-
-        # create PSF model
-        psf = model_frame.psf()
-        if len(psf.shape) == 2:  # only one image for all bands
-            psf_model = jnp.tile(psf, (model_frame.bbox.shape[0], 1, 1))
-        else:
-            psf_model = psf
-        object.__setattr__(self, "_psf_model", psf_model)
-
-    def __call__(self, model, key=None):
-        psf_model = self._psf_model
-
-        if self._padding==None:
-            fft_shape = _get_fast_shape(
-                model.shape, psf_model.shape, padding=self.padding, axes=(-2, -1)
-            )
-        else:
-            fft_shape_ = max(good_fft_size(self._padding*max(model.shape)),
-                             good_fft_size(self._padding*max(psf_model.shape)))
-            
-            fft_shape = [fft_shape_, fft_shape_]
-
-        deconv_ = deconvolve(
-            model, psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True
-        )
-
-        return deconv_
-
-
-class KResampleRenderer(Renderer):
-    """
-    Perform resampling in Fourier space
-
-    Should get as input a Fourier image sampled at the model frame resolution
-    Needs to return a Fourier image sampled at the observation frame resolution
-    """
-
-    def __init__(self, model_frame, obs_frame, padding=None):
-        object.__setattr__(self, "_in_res", model_frame.pixel_size)
-        object.__setattr__(self, "_out_res", obs_frame.pixel_size)
-
-        if padding == None:
-            # use 4 times padding
-            padding = 4
-
-        # find on what grid we will interpolate
-        # fft_out_shape = _get_fast_shape(
-        #     obs_frame.bbox.shape, obs_frame.psf().shape, padding=padding, axes=(-2, -1)
-        # )
-
-        # getting the smallest grid to perform the interpolation
-        # odd shape is required for k-wrapping later
-        _fft_out_shape = min(good_fft_size(padding*max(obs_frame.bbox.shape)),
-                             good_fft_size(padding*max(obs_frame.psf().shape))) + 1
-
-        object.__setattr__(self, "_fft_out_shape", _fft_out_shape)
-
-        # compute resolution ratio for flux conservation
-        object.__setattr__(
-            self, "_resolution_ratio", obs_frame.pixel_size / model_frame.pixel_size
-        )
-
-    def __call__(self, kimage, key=None):
-
-        interpolant = Quintic()
-
-        # compute model k-coordinates of the fourier input image
-        # ky_in = jnp.linspace(-0.5, 0.5, kimage.shape[1]) / self._in_res
-        # kx_in = jnp.linspace(0, 0.5, kimage.shape[1] // 2 + 1) / self._in_res
-
-        # ky_out = jnp.linspace(-0.5, 0.5, self._fft_out_shape[0]) / self._out_res
-        # kx_out = jnp.linspace(0, 0.5, self._fft_out_shape[0] // 2 + 1) / self._out_res
-        shape_in = kimage.shape[1]
-        shape_out = self._fft_out_shape
-
-        kcoords_out = jnp.stack(jnp.meshgrid(
-            jnp.linspace(0, 
-                        shape_in/2/self._out_res*self._in_res, 
-                         shape_out//2+1),
-            jnp.linspace(-shape_in/2/self._out_res*self._in_res, 
-                         shape_in/2/self._out_res*self._in_res, 
-                         shape_out)
-                         ), -1)
-
-        kimage = jnp.fft.fftshift(kimage, -2)
-
-        # kcoords_in = jnp.stack(jnp.meshgrid(kx_in, ky_in), -1)
-        # kcoords_out = jnp.stack(jnp.meshgrid(kx_out, ky_out), -1)
-
-        # k_resampled = jax.vmap(resample2d, in_axes=(0, None, None))(
-        #     kimage, kcoords_in, kcoords_out
-        # )
-
-        k_resampled = jax.vmap(resample_hermitian, in_axes=(0, None, None, None,None))(
-            kimage, kcoords_out, -shape_in/2, -shape_in/2, interpolant)
-        
-        print(k_resampled.shape)
-
-        # multiply with the FFT of the kernel
-        kx = jnp.linspace(0, jnp.pi, shape_out//2 + 1) * self._in_res/self._out_res
-        ky = jnp.linspace(-jnp.pi, jnp.pi, shape_out)
-        coords = jnp.stack(jnp.meshgrid(kx, ky),-1) / 2 / jnp.pi
-
-        xint_val = interpolant.uval(coords[...,0]) * interpolant.uval(coords[...,1])
-        print(xint_val.shape)
-        k_resampled = k_resampled * xint_val
-
-        k_resampled = jnp.fft.ifftshift(k_resampled, -2)
-
-        return k_resampled
-
-
-class KConvolveRenderer(Renderer):
-    """
-    Convolve with obs PSF and return real image
-    """
-
-    def __init__(self, obs_frame, padding=None):
-        object.__setattr__(self, "_obs_shape", obs_frame.bbox.shape)
-
-        if padding == None:
-            # use 4 times padding
-            padding = 4
-            # padding = pad_factor * max(obs_frame.bbox.shape[1], obs_frame.bbox.shape[2])
-        # object.__setattr__(self, "_pad_size", padding)
-        object.__setattr__(self, "_padding", padding)
-
-        # get PSF from obs
-        psf = obs_frame.psf()
-        if len(psf.shape) == 2:  # only one image for all bands
-            psf_model = jnp.tile(psf, (obs_frame.bbox.shape[0], 1, 1))
-        else:
-            psf_model = psf
-        object.__setattr__(self, "_psf_model", psf_model)
-
-
-        # fft_out_shape = _get_fast_shape(
-        #     obs_frame.bbox.shape, obs_frame.psf().shape, padding=padding, axes=(-2, -1)
-        # )
-
-        _fft_out_shape = good_fft_size(padding*max(obs_frame.psf().shape)) + 1
-        fft_out_shape = [_fft_out_shape, _fft_out_shape]
-
-        object.__setattr__(self, "_fft_out_shape", fft_out_shape)
-
-    def __call__(self, kimage, key=None):
-
-        # Convolve with obs PSF
-
-        kpsf = transform(self._psf_model, self._fft_out_shape, (-2, -1))
-
-        kconv = kimage * kpsf
-
-        from jax_galsim.core.wrap_image import wrap_hermitian_x
-        kconv = wrap_hermitian_x(
-                            kconv,
-                            -64,
-                            -64,
-                            -63,
-                            -64,
-                            128,
-                            128
-        )
-
-        kconv = kconv[:,:-1, :]
-
-        fft_out_shape = [self._fft_out_shape[0]-1, self._fft_out_shape[1]]
-        print(kconv.shape)
-        print(self._obs_shape)
-
-        img = inverse(kconv, fft_out_shape, self._obs_shape, axes=(-2, -1))
-
-        return img
-    
 
 """
 Preprocess:
@@ -384,8 +196,22 @@ class ResamplingMultiresRenderer(Renderer):
     
 
 class PostprocessMultiresRenderer(Renderer):
-    def __init__(self):
-        pass
+    def __init__(self, model_frame, obs_frame, padding=None):
+        if padding == None:
+            # use 4 times padding
+            padding = 4
+        object.__setattr__(self, "_padding", padding)
+
+        fft_shape_model_im = good_fft_size(self._padding*max(model_frame.bbox.shape))
+        fft_shape_model_psf = good_fft_size(self._padding*max(model_frame.psf().shape))
+        fft_shape_obs_psf = good_fft_size(self._padding*max(obs_frame.psf().shape))
+        object.__setattr__(self, "real_shape_target", obs_frame.bbox.shape)
+        
+        # getting the smallest grid to perform the interpolation
+        # odd shape is required for k-wrapping later
+        fft_shape_target = min(fft_shape_model_im, fft_shape_model_psf, fft_shape_obs_psf) + 1
+        object.__setattr__(self, "fft_shape_target", fft_shape_target)
+
     def __call__(self, kimages, key=None):
 
         model_kim, model_kpsf, obs_kpsf = kimages
@@ -394,12 +220,12 @@ class PostprocessMultiresRenderer(Renderer):
         
         kimage_final_wrap = jax.vmap(wrap_hermitian_x, in_axes=(0, None, None, None, None, None, None))(
                             kimage_final,
-                            -64,
-                            -64,
-                            -63,
-                            -64,
-                            128,
-                            128
+                            -self.fft_shape_target//2,
+                            -self.fft_shape_target//2,
+                            -self.fft_shape_target//2+1,
+                            -self.fft_shape_target//2,
+                            self.fft_shape_target-1,
+                            self.fft_shape_target-1
         )
 
         kimage_final_wrap = kimage_final_wrap[:, :-1, :]
@@ -408,9 +234,9 @@ class PostprocessMultiresRenderer(Renderer):
 
         real_image_arr = jnp.fft.fftshift(
             jnp.fft.irfft2(kimg_shift, 
-                           [128, 128], (-2, -1)), (-2, -1)
+                           [self.fft_shape_target-1, self.fft_shape_target-1], (-2, -1)), (-2, -1)
         )
 
-        img_trimed = _trim(real_image_arr, [real_image_arr.shape[0], 50,50])
+        img_trimed = _trim(real_image_arr, [real_image_arr.shape[0], self.real_shape_target[-2], self.real_shape_target[-1]])
 
         return img_trimed

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -2,10 +2,11 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax
 
-from .fft import convolve, deconvolve, _get_fast_shape, transform, inverse
+from .fft import convolve, deconvolve, _get_fast_shape, transform, inverse, good_fft_size, _pad, _trim
 
-from .interpolation import resample2d
+from .interpolation import resample_ops, Quintic
 
+from .fft import wrap_hermitian_x
 
 class Renderer(eqx.Module):
     def __call__(
@@ -70,6 +71,7 @@ class ConvolutionRenderer(Renderer):
             psf_model = jnp.tile(psf, (obs_frame.bbox.shape[0], 1, 1))
         else:
             psf_model = psf
+        
         # make sure fft uses a shape large enough to cover the convolved model
         fft_shape = _get_fast_shape(
             model_frame.bbox.shape, psf_model.shape, padding=3, axes=(-2, -1)
@@ -99,11 +101,8 @@ class KDeconvRenderer(Renderer):
 
         if padding == None:
             # use 4 times padding
-            pad_factor = 4
-            padding = pad_factor * max(
-                model_frame.bbox.shape[1], model_frame.bbox.shape[2]
-            )
-        object.__setattr__(self, "_pad_size", padding)
+            padding = 4
+        object.__setattr__(self, "_padding", padding)
 
         # create PSF model
         psf = model_frame.psf()
@@ -115,9 +114,17 @@ class KDeconvRenderer(Renderer):
 
     def __call__(self, model, key=None):
         psf_model = self._psf_model
-        fft_shape = _get_fast_shape(
-            model.shape, psf_model.shape, padding=self._pad_size, axes=(-2, -1)
-        )
+
+        if self._padding==None:
+            fft_shape = _get_fast_shape(
+                model.shape, psf_model.shape, padding=self.padding, axes=(-2, -1)
+            )
+        else:
+            fft_shape_ = max(good_fft_size(self._padding*max(model.shape)),
+                             good_fft_size(self._padding*max(psf_model.shape)))
+            
+            fft_shape = [fft_shape_, fft_shape_]
+
         deconv_ = deconvolve(
             model, psf_model, axes=(-2, -1), fft_shape=fft_shape, return_fft=True
         )
@@ -139,14 +146,19 @@ class KResampleRenderer(Renderer):
 
         if padding == None:
             # use 4 times padding
-            pad_factor = 4
-            padding = pad_factor * max(obs_frame.bbox.shape[1], obs_frame.bbox.shape[2])
+            padding = 4
 
         # find on what grid we will interpolate
-        fft_out_shape = _get_fast_shape(
-            obs_frame.bbox.shape, obs_frame.psf().shape, padding=padding, axes=(-2, -1)
-        )
-        object.__setattr__(self, "_fft_out_shape", fft_out_shape)
+        # fft_out_shape = _get_fast_shape(
+        #     obs_frame.bbox.shape, obs_frame.psf().shape, padding=padding, axes=(-2, -1)
+        # )
+
+        # getting the smallest grid to perform the interpolation
+        # odd shape is required for k-wrapping later
+        _fft_out_shape = min(good_fft_size(padding*max(obs_frame.bbox.shape)),
+                             good_fft_size(padding*max(obs_frame.psf().shape))) + 1
+
+        object.__setattr__(self, "_fft_out_shape", _fft_out_shape)
 
         # compute resolution ratio for flux conservation
         object.__setattr__(
@@ -155,26 +167,50 @@ class KResampleRenderer(Renderer):
 
     def __call__(self, kimage, key=None):
 
-        # compute model k-coordinates of the fourier input image
-        ky_in = jnp.linspace(-0.5, 0.5, kimage.shape[1]) / self._in_res
-        kx_in = jnp.linspace(0, 0.5, kimage.shape[1] // 2 + 1) / self._in_res
+        interpolant = Quintic()
 
-        ky_out = jnp.linspace(-0.5, 0.5, self._fft_out_shape[0]) / self._out_res
-        kx_out = jnp.linspace(0, 0.5, self._fft_out_shape[0] // 2 + 1) / self._out_res
+        # compute model k-coordinates of the fourier input image
+        # ky_in = jnp.linspace(-0.5, 0.5, kimage.shape[1]) / self._in_res
+        # kx_in = jnp.linspace(0, 0.5, kimage.shape[1] // 2 + 1) / self._in_res
+
+        # ky_out = jnp.linspace(-0.5, 0.5, self._fft_out_shape[0]) / self._out_res
+        # kx_out = jnp.linspace(0, 0.5, self._fft_out_shape[0] // 2 + 1) / self._out_res
+        shape_in = kimage.shape[1]
+        shape_out = self._fft_out_shape
+
+        kcoords_out = jnp.stack(jnp.meshgrid(
+            jnp.linspace(0, 
+                        shape_in/2/self._out_res*self._in_res, 
+                         shape_out//2+1),
+            jnp.linspace(-shape_in/2/self._out_res*self._in_res, 
+                         shape_in/2/self._out_res*self._in_res, 
+                         shape_out)
+                         ), -1)
 
         kimage = jnp.fft.fftshift(kimage, -2)
 
-        kcoords_in = jnp.stack(jnp.meshgrid(kx_in, ky_in), -1)
-        kcoords_out = jnp.stack(jnp.meshgrid(kx_out, ky_out), -1)
+        # kcoords_in = jnp.stack(jnp.meshgrid(kx_in, ky_in), -1)
+        # kcoords_out = jnp.stack(jnp.meshgrid(kx_out, ky_out), -1)
 
-        k_resampled = jax.vmap(resample2d, in_axes=(0, None, None))(
-            kimage, kcoords_in, kcoords_out
-        )
+        # k_resampled = jax.vmap(resample2d, in_axes=(0, None, None))(
+        #     kimage, kcoords_in, kcoords_out
+        # )
+
+        k_resampled = jax.vmap(resample_hermitian, in_axes=(0, None, None, None,None))(
+            kimage, kcoords_out, -shape_in/2, -shape_in/2, interpolant)
+        
+        print(k_resampled.shape)
+
+        # multiply with the FFT of the kernel
+        kx = jnp.linspace(0, jnp.pi, shape_out//2 + 1) * self._in_res/self._out_res
+        ky = jnp.linspace(-jnp.pi, jnp.pi, shape_out)
+        coords = jnp.stack(jnp.meshgrid(kx, ky),-1) / 2 / jnp.pi
+
+        xint_val = interpolant.uval(coords[...,0]) * interpolant.uval(coords[...,1])
+        print(xint_val.shape)
+        k_resampled = k_resampled * xint_val
 
         k_resampled = jnp.fft.ifftshift(k_resampled, -2)
-
-        # conserve flux
-        k_resampled = k_resampled
 
         return k_resampled
 
@@ -189,9 +225,10 @@ class KConvolveRenderer(Renderer):
 
         if padding == None:
             # use 4 times padding
-            pad_factor = 4
-            padding = pad_factor * max(obs_frame.bbox.shape[1], obs_frame.bbox.shape[2])
-        object.__setattr__(self, "_pad_size", padding)
+            padding = 4
+            # padding = pad_factor * max(obs_frame.bbox.shape[1], obs_frame.bbox.shape[2])
+        # object.__setattr__(self, "_pad_size", padding)
+        object.__setattr__(self, "_padding", padding)
 
         # get PSF from obs
         psf = obs_frame.psf()
@@ -201,9 +238,14 @@ class KConvolveRenderer(Renderer):
             psf_model = psf
         object.__setattr__(self, "_psf_model", psf_model)
 
-        fft_out_shape = _get_fast_shape(
-            obs_frame.bbox.shape, obs_frame.psf().shape, padding=padding, axes=(-2, -1)
-        )
+
+        # fft_out_shape = _get_fast_shape(
+        #     obs_frame.bbox.shape, obs_frame.psf().shape, padding=padding, axes=(-2, -1)
+        # )
+
+        _fft_out_shape = good_fft_size(padding*max(obs_frame.psf().shape)) + 1
+        fft_out_shape = [_fft_out_shape, _fft_out_shape]
+
         object.__setattr__(self, "_fft_out_shape", fft_out_shape)
 
     def __call__(self, kimage, key=None):
@@ -214,6 +256,161 @@ class KConvolveRenderer(Renderer):
 
         kconv = kimage * kpsf
 
-        img = inverse(kconv, self._fft_out_shape, self._obs_shape, axes=(-2, -1))
+        from jax_galsim.core.wrap_image import wrap_hermitian_x
+        kconv = wrap_hermitian_x(
+                            kconv,
+                            -64,
+                            -64,
+                            -63,
+                            -64,
+                            128,
+                            128
+        )
+
+        kconv = kconv[:,:-1, :]
+
+        fft_out_shape = [self._fft_out_shape[0]-1, self._fft_out_shape[1]]
+        print(kconv.shape)
+        print(self._obs_shape)
+
+        img = inverse(kconv, fft_out_shape, self._obs_shape, axes=(-2, -1))
 
         return img
+    
+
+"""
+Preprocess:
+    - padd img, psf_in and psf_out on the according goodfftsize
+    - return kimages
+
+Resample:
+    - resample the three kimage on the target kgrid
+    - return these images
+
+Postprocess:
+    - multiply these k images
+    - kwrapping
+    - ifft
+"""
+
+class PreprocessMultiresRenderer(Renderer):
+    """
+    Perform padding and Fourier transform of the model image, model psf and
+    observed psf
+    """
+
+    def __init__(self, model_frame, obs_frame, padding=None):
+
+        if padding == None:
+            # use 4 times padding
+            padding = 4
+        object.__setattr__(self, "_padding", padding)
+
+        # create PSF model
+        psf_model = model_frame.psf()
+        
+        if len(psf_model.shape) == 2:  # only one image for all bands
+            psf_model = jnp.tile(psf_model, (model_frame.bbox.shape[0], 1, 1))
+        
+        object.__setattr__(self, "_psf_model", psf_model)
+
+        psf_obs = obs_frame.psf()
+
+        object.__setattr__(self, "_psf_obs", psf_obs)
+
+        fft_shape_model_im = good_fft_size(self._padding*max(model_frame.bbox.shape))
+        fft_shape_model_psf = good_fft_size(self._padding*max(psf_model.shape))
+        fft_shape_obs_psf = good_fft_size(self._padding*max(psf_obs.shape))
+
+        object.__setattr__(self, "fft_shape_model_im", fft_shape_model_im)
+        object.__setattr__(self, "fft_shape_model_psf", fft_shape_model_psf)
+        object.__setattr__(self, "fft_shape_obs_psf", fft_shape_obs_psf)
+
+    def __call__(self, model, key=None):
+        psf_model = self._psf_model
+        psf_obs = self._psf_obs
+
+        model_kim = jnp.fft.fftshift(
+            transform(model, (self.fft_shape_model_im, self.fft_shape_model_im), (-2, -1)),
+            (-2))
+        model_kpsf = jnp.fft.fftshift(
+            transform(psf_model, (self.fft_shape_model_psf, self.fft_shape_model_psf), (-2, -1)),
+            (-2))
+        obs_kpsf = jnp.fft.fftshift(
+            transform(psf_obs, (self.fft_shape_obs_psf, self.fft_shape_obs_psf), (-2, -1)),
+            (-2))
+
+        return model_kim, model_kpsf, obs_kpsf
+    
+class ResamplingMultiresRenderer(Renderer):
+    """
+    Perform the intepolation of the model, model psf and obs psf on the same
+    target grid
+    """
+
+    def __init__(self, model_frame, obs_frame, padding=None):
+        
+        if padding == None:
+            # use 4 times padding
+            padding = 4
+        object.__setattr__(self, "_padding", padding)
+
+        fft_shape_model_im = good_fft_size(self._padding*max(model_frame.bbox.shape))
+        fft_shape_model_psf = good_fft_size(self._padding*max(model_frame.psf().shape))
+        fft_shape_obs_psf = good_fft_size(self._padding*max(obs_frame.psf().shape))
+
+        # getting the smallest grid to perform the interpolation
+        # odd shape is required for k-wrapping later
+        fft_shape_target = min(fft_shape_model_im, fft_shape_model_psf, fft_shape_obs_psf) + 1
+        object.__setattr__(self, "fft_shape_target", fft_shape_target)
+
+        object.__setattr__(self, "res_in", model_frame.pixel_size)
+        object.__setattr__(self, "res_out", obs_frame.pixel_size)
+
+    def __call__(self, kimages, key=None):
+
+        model_kim, model_kpsf, obs_kpsf = kimages
+
+        model_kim_interp = resample_ops(model_kim, model_kim.shape[-2], 
+                                        self.fft_shape_target, self.res_in, self.res_out)
+
+        model_kpsf_interp = resample_ops(model_kpsf, model_kpsf.shape[-2], 
+                                        self.fft_shape_target, self.res_in, self.res_out)
+        
+        obs_kpsf_interp = resample_ops(obs_kpsf, obs_kpsf.shape[-2], 
+                                        self.fft_shape_target, self.res_out, self.res_out)
+        
+        return model_kim_interp, model_kpsf_interp, obs_kpsf_interp
+    
+
+class PostprocessMultiresRenderer(Renderer):
+    def __init__(self):
+        pass
+    def __call__(self, kimages, key=None):
+
+        model_kim, model_kpsf, obs_kpsf = kimages
+
+        kimage_final = model_kim / model_kpsf * obs_kpsf
+        
+        kimage_final_wrap = jax.vmap(wrap_hermitian_x, in_axes=(0, None, None, None, None, None, None))(
+                            kimage_final,
+                            -64,
+                            -64,
+                            -63,
+                            -64,
+                            128,
+                            128
+        )
+
+        kimage_final_wrap = kimage_final_wrap[:, :-1, :]
+    
+        kimg_shift = jnp.fft.ifftshift(kimage_final_wrap, axes=(-2,))
+
+        real_image_arr = jnp.fft.fftshift(
+            jnp.fft.irfft2(kimg_shift, 
+                           [128, 128], (-2, -1)), (-2, -1)
+        )
+
+        img_trimed = _trim(real_image_arr, [real_image_arr.shape[0], 50,50])
+
+        return img_trimed

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -167,8 +167,8 @@ class KResampleRenderer(Renderer):
         kcoords_in = jnp.stack(jnp.meshgrid(kx_in, ky_in), -1)
         kcoords_out = jnp.stack(jnp.meshgrid(kx_out, ky_out), -1)
 
-        k_resampled = jax.vmap(resample2d, in_axes=(0, None, None, None))(
-            kimage, kcoords_in, kcoords_out, 3
+        k_resampled = jax.vmap(resample2d, in_axes=(0, None, None))(
+            kimage, kcoords_in, kcoords_out
         )
 
         k_resampled = jnp.fft.ifftshift(k_resampled, -2)

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -96,13 +96,13 @@ Preprocess:
     - return kimages
 
 Resample:
-    - resample the three kimage on the target kgrid
-    - return these images
+    - resample the three kimages on the target kgrid
+    - return these kimages
 
 Postprocess:
-    - multiply these k images
+    - Deconvolve model PSF and convolve obs PSF in Fourier space
     - kwrapping
-    - ifft
+    - ifft and cropping to obs frame
 """
 
 class PreprocessMultiresRenderer(Renderer):
@@ -156,7 +156,7 @@ class PreprocessMultiresRenderer(Renderer):
     
 class ResamplingMultiresRenderer(Renderer):
     """
-    Perform the intepolation of the model, model psf and obs psf on the same
+    Perform the interpolation of the model, model psf and obs psf on the same
     target grid
     """
 

--- a/tests/test_multiresolution.py
+++ b/tests/test_multiresolution.py
@@ -36,7 +36,6 @@ psf_hst = np.array(psf_hst[None,:,:], np.float32)
 psf_hst = jnp.pad(psf_hst, ((0,0), (1,0), (1,0)))
 psf_hst = np.repeat(psf_hst, 5, 0)
 
-print(psf_hst.shape)
 psf_hst = scarlet2.ArrayPSF(psf_hst)
 
 # Scale the HST data

--- a/tests/test_multiresolution.py
+++ b/tests/test_multiresolution.py
@@ -1,9 +1,15 @@
+import os
 import warnings
 warnings.filterwarnings('ignore')
 
 import numpy as np
 from numpy.testing import assert_allclose
+
 import scarlet2
+
+from utils import import_scarlet_test_data
+import_scarlet_test_data()
+from scarlet_test_data import data_path, tests_path
 
 import numpy as np
 import astropy.io.fits as fits
@@ -12,25 +18,28 @@ from astropy.wcs import WCS
 import jax.numpy as jnp
 
 # Load the HSC image data
-obs_hdu = fits.open('../scarlet-test-data/data/test_resampling/Cut_HSC1.fits')
+obs_hdu = fits.open(os.path.join(data_path, "test_resampling", "Cut_HSC1.fits"))
+                    
 data_hsc = jnp.array(obs_hdu[0].data.byteswap().newbyteorder(), jnp.float32)
 wcs_hsc = WCS(obs_hdu[0].header)
 channels_hsc = ['g','r','i','z','y']
 
 # Load the HSC PSF data
-psf_hsc_data = fits.open('../scarlet-test-data/data/test_resampling/PSF_HSC.fits')[0].data.astype('float32')
+psf_hsc_data  = fits.open(os.path.join(data_path, "test_resampling", "PSF_HSC.fits"))[0].data.astype('float32')
+                    
 Np1, Np2 = psf_hsc_data[0].shape
 psf_hsc_data = jnp.pad(psf_hsc_data, ((0,0), (1,0), (1,0)))
 psf_hsc = scarlet2.ArrayPSF(psf_hsc_data)
 
 # Load the HST image data
-hst_hdu = fits.open('../scarlet-test-data/data/test_resampling/Cut_HST1.fits')
+hst_hdu = fits.open(os.path.join(data_path, "test_resampling", "Cut_HST1.fits"))
+
 data_hst = hst_hdu[0].data
 wcs_hst = WCS(hst_hdu[0].header)
 channels_hst = ['F814W']
 
 # Load the HST PSF data
-psf_hst = fits.open('../scarlet-test-data/data/test_resampling/PSF_HST.fits')[0].data
+psf_hst = fits.open(os.path.join(data_path, "test_resampling", "PSF_HST.fits"))[0].data
 psf_hst = np.array(psf_hst[None,:,:], np.float32)
 psf_hst = jnp.pad(psf_hst, ((0,0), (1,0), (1,0)))
 psf_hst = np.repeat(psf_hst, 5, 0)
@@ -75,6 +84,10 @@ def test_hst_to_hsc_against_galsim():
     hst_resampled = obs_hsc.render(data_hst)
 
     # Perform the same operations with galsim 
-    out_galsim = np.load('../scarlet-test-data/galsim_hst_to_hsc_resolution.npy')
+    # out_galsim = np.load('../scarlet-test-data/galsim_hst_to_hsc_resolution.npy')
+    out_galsim = np.load(os.path.join(tests_path, "galsim_hst_to_hsc_resolution.npy"))
 
     assert_allclose(out_galsim, hst_resampled[0], atol=1.3e-4)
+
+if __name__=="__main__":
+    test_hst_to_hsc_against_galsim()

--- a/tests/test_multiresolution.py
+++ b/tests/test_multiresolution.py
@@ -1,0 +1,116 @@
+import warnings
+warnings.filterwarnings('ignore')
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scarlet2
+import galsim
+
+import numpy as np
+import astropy.io.fits as fits
+from astropy.wcs import WCS
+
+import jax.numpy as jnp
+
+# Load the HSC image data
+obs_hdu = fits.open('../../scarlet/data/test_resampling/Cut_HSC1.fits')
+data_hsc = jnp.array(obs_hdu[0].data.byteswap().newbyteorder(), jnp.float32)
+wcs_hsc = WCS(obs_hdu[0].header)
+channels_hsc = ['g','r','i','z','y']
+
+# Load the HSC PSF data
+psf_hsc_data = fits.open('../../scarlet/data/test_resampling/PSF_HSC.fits')[0].data.astype('float32')
+Np1, Np2 = psf_hsc_data[0].shape
+psf_hsc_data = jnp.pad(psf_hsc_data, ((0,0), (1,0), (1,0)))
+psf_hsc = scarlet2.ArrayPSF(psf_hsc_data)
+
+# Load the HST image data
+hst_hdu = fits.open('../../scarlet/data/test_resampling/Cut_HST1.fits')
+data_hst = hst_hdu[0].data
+wcs_hst = WCS(hst_hdu[0].header)
+channels_hst = ['F814W']
+
+# Load the HST PSF data
+psf_hst = fits.open('../../scarlet/data/test_resampling/PSF_HST.fits')[0].data
+psf_hst = np.array(psf_hst[None,:,:], np.float32)
+psf_hst = jnp.pad(psf_hst, ((0,0), (1,0), (1,0)))
+psf_hst = np.repeat(psf_hst, 5, 0)
+
+print(psf_hst.shape)
+psf_hst = scarlet2.ArrayPSF(psf_hst)
+
+# Scale the HST data
+n1,n2 = np.shape(data_hst)
+data_hst = data_hst.reshape(1, n1, n2).byteswap().newbyteorder()
+data_hst *= data_hsc.max() / data_hst.max()
+
+r, N1, N2 = data_hsc.shape
+
+# define two observation packages and match to frame
+obs_hst = scarlet2.Observation(data_hst[:1, ...],
+                               wcs=wcs_hst,
+                               psf=psf_hst,
+                               channels=['channel'],
+                               weights=None)
+
+obs_hsc = scarlet2.Observation(data_hsc[:1,...],
+                              wcs=wcs_hsc,
+                              psf=psf_hsc,
+                              channels=['channel'],
+                              weights=None)
+
+# Building a Frame from hst obs
+
+hst_frame = scarlet2.Frame(
+                bbox=scarlet2.Box(shape=data_hst.shape),
+                channels=['channel'],
+                psf=psf_hst,
+                wcs=wcs_hst
+)
+
+def test_hst_to_hsc_against_galsim():
+
+    # Initializing renderers
+    obs_hsc.match(hst_frame)
+
+    # Deconvolution, Resampling and Reconvolution
+    hst_resampled = obs_hsc.render(data_hst)
+
+    # Perform the same operations with galsim 
+
+    # Initialize images
+    h_hst = 0.03
+    h_hsc = 0.168
+
+    gi_hst_im = galsim.Image(np.array(data_hst[0]), scale=h_hst)
+
+    gii_hst_im = galsim.InterpolatedImage(gi_hst_im, 
+                                    x_interpolant=galsim.Quintic(),
+                                k_interpolant=galsim.Quintic()
+                                )
+
+    hst_psf = psf_hst()[0]
+
+    gi_hst_psf = galsim.Image(np.array(hst_psf), scale=h_hst)
+    gii_hst_psf = galsim.InterpolatedImage(gi_hst_psf,
+                                x_interpolant=galsim.Quintic(),
+                                k_interpolant=galsim.Quintic()
+                                )
+
+    hsc_psf = psf_hsc()[0]
+
+    gi_hsc_psf = galsim.Image(np.array(hsc_psf), scale=h_hsc)
+    gii_hsc_psf = galsim.InterpolatedImage(gi_hsc_psf,
+                                x_interpolant=galsim.Quintic(),
+                                k_interpolant=galsim.Quintic()
+                                )
+
+    # Deconvolution and Reconvolution
+    inv_gii_hst_psf = galsim.Deconvolve(gii_hst_psf)
+    deconv_hst = galsim.Convolve(inv_gii_hst_psf, gii_hst_im)
+    reconv_hsc = galsim.Convolve(gii_hsc_psf, deconv_hst)
+
+    out_galsim = reconv_hsc.drawImage(nx=N1, ny=N2, scale=0.168, method='no_pixel')
+
+
+    assert_allclose(out_galsim.array, hst_resampled[0], atol=1.3e-4)

--- a/tests/test_multiresolution.py
+++ b/tests/test_multiresolution.py
@@ -4,7 +4,6 @@ warnings.filterwarnings('ignore')
 import numpy as np
 from numpy.testing import assert_allclose
 import scarlet2
-import galsim
 
 import numpy as np
 import astropy.io.fits as fits
@@ -76,40 +75,6 @@ def test_hst_to_hsc_against_galsim():
     hst_resampled = obs_hsc.render(data_hst)
 
     # Perform the same operations with galsim 
+    out_galsim = np.load('../scarlet-test-data/galsim_hst_to_hsc_resolution.npy')
 
-    # Initialize images
-    h_hst = 0.03
-    h_hsc = 0.168
-
-    gi_hst_im = galsim.Image(np.array(data_hst[0]), scale=h_hst)
-
-    gii_hst_im = galsim.InterpolatedImage(gi_hst_im, 
-                                    x_interpolant=galsim.Quintic(),
-                                k_interpolant=galsim.Quintic()
-                                )
-
-    hst_psf = psf_hst()[0]
-
-    gi_hst_psf = galsim.Image(np.array(hst_psf), scale=h_hst)
-    gii_hst_psf = galsim.InterpolatedImage(gi_hst_psf,
-                                x_interpolant=galsim.Quintic(),
-                                k_interpolant=galsim.Quintic()
-                                )
-
-    hsc_psf = psf_hsc()[0]
-
-    gi_hsc_psf = galsim.Image(np.array(hsc_psf), scale=h_hsc)
-    gii_hsc_psf = galsim.InterpolatedImage(gi_hsc_psf,
-                                x_interpolant=galsim.Quintic(),
-                                k_interpolant=galsim.Quintic()
-                                )
-
-    # Deconvolution and Reconvolution
-    inv_gii_hst_psf = galsim.Deconvolve(gii_hst_psf)
-    deconv_hst = galsim.Convolve(inv_gii_hst_psf, gii_hst_im)
-    reconv_hsc = galsim.Convolve(gii_hsc_psf, deconv_hst)
-
-    out_galsim = reconv_hsc.drawImage(nx=N1, ny=N2, scale=0.168, method='no_pixel')
-
-
-    assert_allclose(out_galsim.array, hst_resampled[0], atol=1.3e-4)
+    assert_allclose(out_galsim, hst_resampled[0], atol=1.3e-4)

--- a/tests/test_multiresolution.py
+++ b/tests/test_multiresolution.py
@@ -12,25 +12,25 @@ from astropy.wcs import WCS
 import jax.numpy as jnp
 
 # Load the HSC image data
-obs_hdu = fits.open('../../scarlet/data/test_resampling/Cut_HSC1.fits')
+obs_hdu = fits.open('../scarlet-test-data/data/test_resampling/Cut_HSC1.fits')
 data_hsc = jnp.array(obs_hdu[0].data.byteswap().newbyteorder(), jnp.float32)
 wcs_hsc = WCS(obs_hdu[0].header)
 channels_hsc = ['g','r','i','z','y']
 
 # Load the HSC PSF data
-psf_hsc_data = fits.open('../../scarlet/data/test_resampling/PSF_HSC.fits')[0].data.astype('float32')
+psf_hsc_data = fits.open('../scarlet-test-data/data/test_resampling/PSF_HSC.fits')[0].data.astype('float32')
 Np1, Np2 = psf_hsc_data[0].shape
 psf_hsc_data = jnp.pad(psf_hsc_data, ((0,0), (1,0), (1,0)))
 psf_hsc = scarlet2.ArrayPSF(psf_hsc_data)
 
 # Load the HST image data
-hst_hdu = fits.open('../../scarlet/data/test_resampling/Cut_HST1.fits')
+hst_hdu = fits.open('../scarlet-test-data/data/test_resampling/Cut_HST1.fits')
 data_hst = hst_hdu[0].data
 wcs_hst = WCS(hst_hdu[0].header)
 channels_hst = ['F814W']
 
 # Load the HST PSF data
-psf_hst = fits.open('../../scarlet/data/test_resampling/PSF_HST.fits')[0].data
+psf_hst = fits.open('../scarlet-test-data/data/test_resampling/PSF_HST.fits')[0].data
 psf_hst = np.array(psf_hst[None,:,:], np.float32)
 psf_hst = jnp.pad(psf_hst, ((0,0), (1,0), (1,0)))
 psf_hst = np.repeat(psf_hst, 5, 0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,25 @@
+import pip
+import importlib
+
+package_name = "scarlet_test_data"
+package_link = "git+https://github.com/astro-data-lab/scarlet-test-data.git"
+
+def install(package):
+    if hasattr(pip, 'main'):
+        pip.main(['install', package])
+    else:
+        pip._internal.main(['install', package])
+
+def import_scarlet_test_data():
+    try:
+        import scarlet_test_data
+
+    except ImportError:
+        install(package_link)
+    
+    finally:
+        globals()[package_name] = importlib.import_module(package_name)
+
+if __name__=="__main__":
+    import_scarlet_test_data()
+    print(scarlet_test_data.data_path)


### PR DESCRIPTION
This PR updates the resampling renderer strategy by interpolating all the images (observation and PSFs) on the same grid in Fourier space and adds k-wrapping ([Bernstein & Gruen 2014](https://arxiv.org/abs/1401.2636)) to match galsim resampling. Some refactoring has been done in `interpolation.py` as well and a test can be run with data soon [here](https://github.com/astro-data-lab/scarlet-test-data).