### PR TITLE
added options to NUTS; closes #57

### DIFF
--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import jax.scipy
 
 from .bbox import Box
-from .module import Module, Parameter
+from .module import Module
 
 
 class Morphology(Module):
@@ -13,11 +13,7 @@ class Morphology(Module):
         return x / x.max()
 
     def center_bbox(self, center):
-        if isinstance(center, Parameter):
-            center_ = center.value
-        else:
-            center_ = center
-        self.bbox.set_center(center_.astype(int))
+        self.bbox.set_center(center.astype(int))
 
 
 class ArrayMorphology(Morphology):

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -45,7 +45,7 @@ class Scene(Module):
     def __exit__(self, exc_type, exc_value, traceback):
         Scenery.scene = None
 
-    def sample(self, observations, parameters, num_warmup=50, num_samples=100, **kwargs):
+    def sample(self, observations, parameters, seed=0, num_warmup=100, num_samples=200, **kwargs):
         # uses numpyro NUTS on all non-fixed parameters
         # requires that those have priors set
         try:
@@ -55,6 +55,10 @@ class Scene(Module):
             from numpyro.infer import MCMC, NUTS
         except ImportError:
             raise ImportError("scarlet2.Scene.sample() requires numpyro.")
+
+        # making sure we can iterate
+        if not isinstance(observations, (list, tuple)):
+            observations = (observations,)
 
         # helper class to turn observation likelihood(s) into numpyro distribution
         class ObsDistribution(dist.Distribution):
@@ -92,19 +96,16 @@ class Scene(Module):
         # and the observations sample from their likelihood given the rendered model
         def pyro_model(model, obs=None):
             samples = tuple(numpyro.sample(p.name, p.prior) for p in parameters)
-            model = model.replace(parameters, samples)
-            pred = model()  # create prediction once for all observations
+            model_ = model.replace(parameters, samples)
+            pred = model_()  # create prediction once for all observations
             # dealing with multiple observations
-            if not isinstance(observations, (list, tuple)):
-                numpyro.sample('obs', ObsDistribution(obs, pred), obs=obs.data)
-            else:
-                for i, obs_ in enumerate(obs):
-                    numpyro.sample(f'obs.{i}', ObsDistribution(obs_, pred), obs=obs_.data)
+            for i, obs_ in enumerate(obs):
+                numpyro.sample(f'obs.{i}', ObsDistribution(obs_, pred), obs=obs_.data)
 
         from numpyro.infer import MCMC, NUTS
-        nuts_kernel = NUTS(pyro_model, dense_mass=True)
+        nuts_kernel = NUTS(pyro_model, **kwargs)
         mcmc = MCMC(nuts_kernel, num_warmup=num_warmup, num_samples=num_samples)
-        rng_key = jax.random.PRNGKey(0)
+        rng_key = jax.random.PRNGKey(seed)
         mcmc.run(rng_key, self, obs=observations)
         return mcmc
 
@@ -178,10 +179,7 @@ class Scene(Module):
 
                 # report current iteration results to callback
                 if callback is not None:
-                    if constraint_fns is not None:
-                        scene_ = _constraint_replace(scene, parameters)
-                    else:
-                        scene_ = scene
+                    scene_ = _constraint_replace(scene, parameters)
                     callback(scene_, convergence, loss)
 
                 # Log the loss and max_change in the tqdm progress bar

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -45,7 +45,7 @@ class Scene(Module):
     def __exit__(self, exc_type, exc_value, traceback):
         Scenery.scene = None
 
-    def sample(self, observations, parameters, seed=0, num_warmup=100, num_samples=200, **kwargs):
+    def sample(self, observations, parameters, seed=0, num_warmup=100, num_samples=200, progress_bar=True, **kwargs):
         # uses numpyro NUTS on all non-fixed parameters
         # requires that those have priors set
         try:
@@ -104,7 +104,7 @@ class Scene(Module):
 
         from numpyro.infer import MCMC, NUTS
         nuts_kernel = NUTS(pyro_model, **kwargs)
-        mcmc = MCMC(nuts_kernel, num_warmup=num_warmup, num_samples=num_samples)
+        mcmc = MCMC(nuts_kernel, num_warmup=num_warmup, num_samples=num_samples, progress_bar=progress_bar)
         rng_key = jax.random.PRNGKey(seed)
         mcmc.run(rng_key, self, obs=observations)
         return mcmc

--- a/scarlet2/source.py
+++ b/scarlet2/source.py
@@ -17,7 +17,9 @@ class Component(Module):
     morphology: Morphology
 
     def __init__(self, center, spectrum, morphology):
+        assert isinstance(spectrum, Spectrum)
         self.spectrum = spectrum
+        assert isinstance(morphology, Morphology)
         self.morphology = morphology
         self.morphology.center_bbox(center)
 
@@ -110,5 +112,5 @@ class PointSource(Source):
 
         # use frame's PSF but with free center parameter
         morphology = copy.deepcopy(frame.psf.morphology)
-        morphology.set("center", center)
+        object.__setattr__(morphology, 'center', center)
         super().__init__(center, spectrum, morphology)


### PR DESCRIPTION
This PR fixes #57 and brings more flexibility to run the MCMC sampler. We can now specify the full set of arguments for the [NUTS sampler](https://num.pyro.ai/en/latest/mcmc.html#numpyro.infer.hmc.NUTS) from numpyro.

For reference, these are a few example uses:
```python

import numpyro.distributions as dist
parameters = scene.make_parameters()
prior = dist.Normal(scene.sources[0].morphology.center, scale=0.1)
parameters += Parameter(scene.sources[0].morphology.center, name="center:0", prior=prior)

from numpyro.infer.initialization import init_to_sample
num_samples = 100
mcmc = scene.sample(obs, parameters, num_samples=num_samples, dense_mass=True, init_strategy=init_to_sample)
mcmc.print_summary()

import corner
corner.corner(mcmc).show()

scenes = []
samples = mcmc.get_samples()
for i in range(num_samples):
    sample_ = tuple(samples[p.name][i] for p in parameters)
    scenes.append(scene.replace(parameters, sample_))

ani = plot.scene(scenes, obs, norm=norm, show_model=True, show_rendered=True, show_observed=True, show_residual=True)
ani.save("test.mp4")
```
which produces summaries and corner plots and a video of the sampler results (you have to look hard for the residuals of the point source fit, the center is constrained to within 0.002 of a pixel):

https://github.com/pmelchior/scarlet2/assets/1463403/4bd1c657-3c9d-4203-bd6b-7cd17d41f034

