### PR TITLE
starlet morphology

### DIFF
--- a/scarlet2/__init__.py
+++ b/scarlet2/__init__.py
@@ -9,7 +9,7 @@ from . import plot
 from .bbox import Box
 from .frame import Frame
 from .module import Parameter, Module, relative_step
-from .morphology import Morphology, ArrayMorphology, GaussianMorphology, SersicMorphology
+from .morphology import Morphology, ArrayMorphology, GaussianMorphology, SersicMorphology, StarletMorphology
 from .observation import Observation
 from .psf import PSF, ArrayPSF, GaussianPSF
 from .scene import Scene


### PR DESCRIPTION
This PR adds the starlet parameterization for source morphologies.

It's enabled by the starlet implementation from #60, but I needed to add the method `starlet_reconstruction` from scarlet1.

One can now do this:
```python
center = jnp.array(center)
spectrum = init.pixel_spectrum(obs, center)
morph = init.adaptive_gaussian_morph(obs, center, min_corr=0.99)
morph = StarletMorphology.from_image(morph)
Source(center, ArraySpectrum(spectrum), morph)
```

This parameterization is useful for spatially correlated structures (like low SFB features), but without additional constraints that model isn't terribly useful because the starlet basis is overcomplete. That is, if an image can describe the morphology, so can a starlet model. However, it get's interesting if these coefficients are constrained to be positive and sparse (only a few of them are non-zero). Sparsity is usually created by the loss function (L0 or L1 penalty on the coefficients), which is not something I would like to do. But in scarlet1, we used proximal operators to create the sparse solution. This could be done explicitly in `StarletMorphology.__call__`. I think one can stick the [soft thresholding operator](https://github.com/pmelchior/proxmin/blob/master/proxmin/operators.py#L138-L150) (which promotes L1 sparsity) into the forward path and still differentiate. I'll check.