### PR TITLE
Deimos

### DIFF
--- a/scarlet2/bbox.py
+++ b/scarlet2/bbox.py
@@ -112,6 +112,12 @@ class Box(eqx.Module):
         """
         return tuple([slice(o, o + s) for o, s in zip(self.origin, self.shape)])
 
+    @property
+    def spatial(self):
+        """Spatial component of higher-dimensional box"""
+        assert self.D >= 2
+        return self[-2:]
+
     def set_center(self, pos):
         """Center box at given position
         """

--- a/scarlet2/plot.py
+++ b/scarlet2/plot.py
@@ -542,17 +542,14 @@ def log_like(morph, spectrum, data, weights):
 # https://arxiv.org/pdf/2006.00719.pdf
 
 # for regular functions f
-#@jax.jit
 def hvp(f, primals, tangents):
     return jvp(grad(f), primals, tangents)[1]
 
 # for score functions
-#@jax.jit
 def hvp_grad(grad_f, primals, tangents):
     return jvp(grad_f, primals, tangents)[1]
 
 # diagonals of Hessian from HVPs
-#@jax.jit
 def hvp_rad(hvp, shape):
     max_iters = 100 # maximum number of iterations
     H = jnp.zeros(shape, dtype=jnp.float32)
@@ -569,7 +566,6 @@ def hvp_rad(hvp, shape):
     return H/(i+1) 
 
 #TODO: fix the jit compilation errors here
-#@jax.jit
 def hallucination_score(scene, obs, src_num):
     src = scene.sources[src_num]
     center = np.array(src.morphology.bbox.center)[::-1]


### PR DESCRIPTION
This PR implements the moment deconvolution method (closes #48), so that an initial Gaussian from `adaptive_gaussian_morph` is computed for the deconvolved model frame rather then the convolved observed frame.

It also updates the spectrum using the zeroth moment, which is the integrated flux. This is somewhat dangerous in the presence of nearby objects (in that case `pixel_spectrum` is the safest choice), but it has lower variance (more pixel contribute).

Because of the deconvolution, the moments might be ill-defined, which will throw a `ValueError`, so the recommended pattern is:
```python
try:
    spectrum, morph = init.adaptive_gaussian_morph(obs, center, min_corr=0.99)
except ValueError:
    spectrum = init.pixel_spectrum(obs, center)
    morph = init.compact_morphology()
```