### PR TITLE
Consistent coordinates

### DIFF
--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -124,7 +124,7 @@ class Frame(eqx.Module):
         pixel_size = get_pixel_size(
             get_affine(self.wcs.celestial) # only use celestial portion
         ) # in deg/pixel
-        print(pixel_size)
+        
         return size.to(u.deg).value / pixel_size
 
     @staticmethod

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -55,7 +55,7 @@ class ProfileMorphology(Morphology):
                 raise
 
         if isinstance(size, u.Quantity):
-            try
+            try:
                 size = Scenery.scene.frame.u_to_pixel(size)
             except AttributeError:
                 print("`size` defined in astropy units can only be used within the context of a Scene")

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -7,6 +7,7 @@ from .module import Module
 from . import Scenery
 
 from astropy.coordinates import SkyCoord
+import astropy.units as u
 
 class Morphology(Module):
     bbox: Box = eqx.field(static=True, init=False)
@@ -44,6 +45,22 @@ class ProfileMorphology(Morphology):
     ellipticity: (None, jnp.array)
 
     def __init__(self, center, size, ellipticity=None, bbox=None):
+
+        if isinstance(center, SkyCoord):
+            try:
+                center = Scenery.scene.frame.get_pixel(center)
+            except AttributeError:
+                print("`center` defined in sky coordinates can only be used within the context of a Scene")
+                print("Use 'with Scene(frame) as scene: (...)'")
+                raise
+
+        if isinstance(size, u.Quantity):
+            try
+                size = Scenery.scene.frame.u_to_pixel(size)
+            except AttributeError:
+                print("`size` defined in astropy units can only be used within the context of a Scene")
+                print("Use 'with Scene(frame) as scene: (...)'")
+                raise
 
         # define radial profile function
         self.center = center

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -4,7 +4,9 @@ import jax.scipy
 
 from .bbox import Box
 from .module import Module
+from . import Scenery
 
+from astropy.coordinates import SkyCoord
 
 class Morphology(Module):
     bbox: Box = eqx.field(static=True, init=False)
@@ -13,6 +15,15 @@ class Morphology(Module):
         return x / x.max()
 
     def center_bbox(self, center):
+
+        if isinstance(center, SkyCoord):
+            try:
+                center = Scenery.scene.frame.get_pixel(center)
+            except AttributeError:
+                print("`center` defined in sky coordinates can only be created within the context of a Scene")
+                print("Use 'with Scene(frame) as scene: (...)'")
+                raise
+
         self.bbox.set_center(center.astype(int))
 
 

--- a/scarlet2/source.py
+++ b/scarlet2/source.py
@@ -4,6 +4,7 @@ import operator
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from astropy.coordinates import SkyCoord
 
 from . import Scenery
 from .bbox import overlap_slices
@@ -112,5 +113,13 @@ class PointSource(Source):
 
         # use frame's PSF but with free center parameter
         morphology = copy.deepcopy(frame.psf.morphology)
+
+        if isinstance(center, SkyCoord):
+            try:
+                center = Scenery.scene.frame.get_pixel(center)
+            except AttributeError:
+                print("`center` defined in sky coordinates can only be created within the context of a Scene")
+                print("Use 'with Scene(frame) as scene: (...)'")
+                raise
         object.__setattr__(morphology, 'center', center)
         super().__init__(center, spectrum, morphology)


### PR DESCRIPTION
This PR solves #51 . The code will be able to accept either pixel coordinates and quantities as well as sky coordianates and astropy quantities. Here are some details of the implementation:

1. `frame.get_pixel` now expects `SkyCoord` objects (or list of) and returns pixel coordinates as arrays and `frame.get_sky_coord` expects pixel coordiantes as arrays and returns `SkyCoord` (or list of), to remove any ambiguity. If it's an array, then it is pixel coordinates, if it is `SkyCoord`, then it is sky coordinates.
2. Anytime a `SkyCoord` of `u.Quantity` object is used in `__init__`, it looks for the scene and convert it to pixels
3. Same thing for `Parameter`, but in addition:
a. I had to move the content of `set_constraint()` from the `Parameter.__init__` to `Parameter.__iadd__`because we need to convert the constraints parameters to pixels before checking the constraints, which expects arrays and floating arguments.
b. numpyro priors require a special treatement because we not only need to update the distribution parameters (e.g. loc and scale) but also the batch and event shape. For instance
```python
numpyro.dist.Normal(loc=SkyCoord(ra=0, dec=0, unit='deg'), scale=1*u.arcsec)
```
would set `batch_shape=0` and `event_shape=0` and converting loc and scale to pixels does not automatically update the batch_shape, while
```python
numpyro.dist.Normal(loc=[0., 0.], scale=1)
```
would set `batch_shape=2` and `event_shape=0`

[Here is a notebook](https://colab.research.google.com/drive/1ZzQHT0OgoGKOaRzu66yhD5sYlCYVFak8?usp=sharing) which uses `SkyCoord` and `u.Quantity` for all fieldname in ['node', 'constraint', 'prior', 'stepsize']