### PR TITLE
Fix channels in pre-rendered model plot

### DIFF
--- a/scarlet2/plot.py
+++ b/scarlet2/plot.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from jax import jvp, grad, jit
 from matplotlib.patches import Rectangle, Polygon
-
+from .renderer import ChannelRenderer
 from .bbox import Box
 
 
@@ -855,8 +855,13 @@ def scene(
     model = scene()
     if show_model:
         extent = get_extent(observation.frame.bbox)
+        if channel_map is None:
+            c = ChannelRenderer(scene.frame, observation.frame).channel_map
+            model_ = model[c]
+        else:
+            model_ = model
         model_img = ax[panel].imshow(
-            img_to_rgb(model, norm=norm, channel_map=channel_map),
+            img_to_rgb(model_, norm=norm, channel_map=channel_map),
             extent=extent,
             origin="lower",
         )


### PR DESCRIPTION
This PR solves #62. Pre-renderered models were plotted with all the channels, now the model is filtered with the ChannelRenderer of the observation.
```python
scarlet2.plot.scene(scene, observation=obs_hsc, show_rendered=True, show_observed=True, show_residual=True)
```
before
![image](https://github.com/pmelchior/scarlet2/assets/30293694/058a981f-040c-41c3-bf31-88bd93822a1b)

after
![image](https://github.com/pmelchior/scarlet2/assets/30293694/73314667-320e-4d30-92ca-46f89ebdd596)
