### PR TITLE
Source has center

### DIFF
--- a/scarlet2/initialization.py
+++ b/scarlet2/initialization.py
@@ -22,7 +22,7 @@ def _get_edge_pixels(img, box):
     return jnp.concatenate(edge, axis=1)
 
 
-def adaptive_gaussian_morph(obs, center, min_size=11, delta_size=3, min_snr=20, min_corr=0.99, return_array=False):
+def adaptive_morphology(obs, center, min_size=11, delta_size=3, min_snr=20, min_corr=0.99, return_array=False):
     """
     Create image of a Gaussian from the centered 2nd moments of the observation.
 
@@ -125,7 +125,7 @@ def compact_morphology(min_value=1e-6, return_array=False):
 
 def gaussian_morphology(
         obs,
-        bbox,
+        bbox=None,
         center=None,
         min_value=1e-6,
         return_array=False
@@ -149,6 +149,8 @@ def gaussian_morphology(
     jnp.ndarrays (for spectrum and morphology) or ArraySpectrum, ArrayMorphology
     """
     # cut out image from observation
+    if bbox is None:
+        bbox = Box(obs.data.shape)
     cutout_img = obs.data[bbox.slices]
     if center is None:
         # define reference center, flatten image across channels

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -32,11 +32,6 @@ class ArrayMorphology(Morphology):
     def shape(self):
         return self.data.shape
 
-    @staticmethod
-    def from_morphology(morph):
-        image = morph()
-        return ArrayMorphology(image)
-
 
 class ProfileMorphology(Morphology):
     size: float

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -1,33 +1,21 @@
+import astropy.units as u
 import equinox as eqx
 import jax.numpy as jnp
 import jax.scipy
 
-from .bbox import Box
-from .module import Module
 from . import Scenery
+from .module import Module
 from .wavelets import starlet_transform, starlet_reconstruction
 
 
-from astropy.coordinates import SkyCoord
-import astropy.units as u
-
 class Morphology(Module):
-    bbox: Box = eqx.field(static=True, init=False)
+
+    @property
+    def shape(self):
+        raise NotImplementedError
 
     def normalize(self, x):
         return x / x.max()
-
-    def center_bbox(self, center):
-
-        if isinstance(center, SkyCoord):
-            try:
-                center = Scenery.scene.frame.get_pixel(center)
-            except AttributeError:
-                print("`center` defined in sky coordinates can only be created within the context of a Scene")
-                print("Use 'with Scene(frame) as scene: (...)'")
-                raise
-
-        self.bbox.set_center(center.astype(int))
 
 
 class ArrayMorphology(Morphology):
@@ -35,26 +23,21 @@ class ArrayMorphology(Morphology):
 
     def __init__(self, data):
         self.data = data
-        self.bbox = Box(self.data.shape)
 
-    def __call__(self):
+    def __call__(self, **kwargs):
         return self.normalize(self.data)
+
+    @property
+    def shape(self):
+        return self.data.shape
 
 
 class ProfileMorphology(Morphology):
-    center: jnp.array
     size: float
     ellipticity: (None, jnp.array)
+    _shape: tuple = eqx.field(static=True, init=False, repr=False)
 
-    def __init__(self, center, size, ellipticity=None, bbox=None):
-
-        if isinstance(center, SkyCoord):
-            try:
-                center = Scenery.scene.frame.get_pixel(center)
-            except AttributeError:
-                print("`center` defined in sky coordinates can only be used within the context of a Scene")
-                print("Use 'with Scene(frame) as scene: (...)'")
-                raise
+    def __init__(self, size, ellipticity=None, shape=None):
 
         if isinstance(size, u.Quantity):
             try:
@@ -64,30 +47,30 @@ class ProfileMorphology(Morphology):
                 print("Use 'with Scene(frame) as scene: (...)'")
                 raise
 
-        # define radial profile function
-        self.center = center
         self.size = size
         self.ellipticity = ellipticity
 
-        if bbox is None:
-            max_size = jnp.max(self.size)
+        # default shape: square 10x size
+        if shape is None:
             # explicit call to int() to avoid bbox sizes being jax-traced
-            size = 10 * int(jnp.ceil(max_size))
+            size = 10 * int(jnp.ceil(self.size))
+            # odd shapes for unique center pixel
             if size % 2 == 0:
                 size += 1
-            center_int = jnp.floor(self.center)
             shape = (size, size)
-            origin = (int(center_int[0]) - size // 2, int(center_int[1]) - size // 2)
-            bbox = Box(shape, origin=origin)
-        self.bbox = bbox
+        self._shape = shape
+
+    @property
+    def shape(self):
+        return self._shape
 
     def f(self, R2):
         raise NotImplementedError
 
-    def __call__(self):
+    def __call__(self, delta_center=jnp.zeros(2)):
 
-        _Y = jnp.arange(self.bbox.shape[-2], dtype=float) + self.bbox.origin[-2] - self.center[-2]
-        _X = jnp.arange(self.bbox.shape[-1], dtype=float) + self.bbox.origin[-1] - self.center[-1]
+        _Y = jnp.arange(-(self.shape[-2] // 2), self.shape[-2] // 2 + 1, dtype=float) + delta_center[-2]
+        _X = jnp.arange(-(self.shape[-1] // 2), self.shape[-1] // 2 + 1, dtype=float) + delta_center[-1]
 
         if self.ellipticity is None:
             R2 = _Y[:, None] ** 2 + _X[None, :] ** 2
@@ -114,12 +97,12 @@ class GaussianMorphology(ProfileMorphology):
     def f(self, R2):
         return jnp.exp(-R2 / 2)
 
-    def __call__(self):
+    def __call__(self, delta_center=jnp.zeros(2)):
 
         # faster circular 2D Gaussian: instead of N^2 evaluations, use outer product of 2 1D Gaussian evals
         if self.ellipticity is None:
-            _Y = jnp.arange(self.bbox.shape[-2]) + self.bbox.origin[-2] - self.center[-2]
-            _X = jnp.arange(self.bbox.shape[-1]) + self.bbox.origin[-1] - self.center[-1]
+            _Y = jnp.arange(-(self.shape[-2] // 2), self.shape[-2] // 2 + 1, dtype=float) + delta_center[-2]
+            _X = jnp.arange(-(self.shape[-1] // 2), self.shape[-1] // 2 + 1, dtype=float) + delta_center[-1]
 
             # with pixel integration
             f = lambda x, s: 0.5 * (
@@ -132,15 +115,15 @@ class GaussianMorphology(ProfileMorphology):
             return self.normalize(jnp.outer(f(_Y, self.size), f(_X, self.size)))
 
         else:
-            return super().__call__()
+            return super().__call__(delta_center)
 
 
 class SersicMorphology(ProfileMorphology):
     n: float
 
-    def __init__(self, n, center, size, ellipticity=None, bbox=None):
+    def __init__(self, n, size, ellipticity=None):
         self.n = n
-        super().__init__(center, size, ellipticity=ellipticity, bbox=bbox)
+        super().__init__(size, ellipticity=ellipticity)
 
     def f(self, R2):
         n = self.n
@@ -169,25 +152,19 @@ prox_soft_plus = lambda x, thresh: prox_plus(prox_soft(x, thresh))
 
 class StarletMorphology(Morphology):
     coeffs: jnp.ndarray
-    l1_thresh: float = eqx.field(static=True)
-    positive: bool = eqx.field(static=True)
+    l1_thresh: float = eqx.field(default=1e-2, static=True)
+    positive: bool = eqx.field(default=True, static=True)
 
-    def __init__(self, coeffs, l1_thresh=1e-2, positive=True, bbox=None):
-        if bbox is None:
-            # wavelet coeffs: scales x n1 x n2
-            bbox = Box(coeffs.shape[-2:])
-        self.bbox = bbox
-
-        self.coeffs = coeffs
-        self.l1_thresh = l1_thresh
-        self.positive = positive
-
-    def __call__(self):
+    def __call__(self, **kwargs):
         if self.positive:
             f = prox_soft_plus
         else:
             f = prox_soft
         return self.normalize(starlet_reconstruction(f(self.coeffs, self.l1_thresh)))
+
+    @property
+    def shape(self):
+        return self.coeffs.shape[-2:]  # wavelet coeffs: scales x n1 x n2
 
     @staticmethod
     def from_image(image, **kwargs):

--- a/scarlet2/plot.py
+++ b/scarlet2/plot.py
@@ -9,8 +9,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 from jax import jvp, grad, jit
 from matplotlib.patches import Rectangle, Polygon
-from .renderer import ChannelRenderer
+
 from .bbox import Box
+from .renderer import ChannelRenderer
 
 
 def channels_to_rgb(channels):
@@ -899,12 +900,7 @@ def scene(
 
     for k, src in enumerate(scene.sources):
         
-        if hasattr(src.morphology.bbox, "center") and src.morphology.bbox.center is not None:
-            center = np.array(src.morphology.bbox.center)[::-1]
-        else:
-            center = None
-        
-        start, stop = src.morphology.bbox.start[-2:][::-1], src.morphology.bbox.stop[-2:][::-1]
+        start, stop = src.bbox.start[-2:][::-1], src.bbox.stop[-2:][::-1]
         points = (start, (start[0], stop[1]), stop, (stop[0], start[1]))
         box_coords = [
             p for p in points
@@ -927,7 +923,8 @@ def scene(
                     poly = Polygon(box_coords, closed=True, **box_kwargs)
                     ax[panel].add_artist(poly)
 
-        if add_labels and hasattr(src.morphology.bbox, "center") and center is not None:
+        if add_labels:
+            center = np.array(src.center)[::-1]
             panel = 0
             if show_model:
                 ax[panel].text(*center, k, **label_kwargs)

--- a/scarlet2/psf.py
+++ b/scarlet2/psf.py
@@ -19,7 +19,7 @@ class GaussianPSF(PSF):
     morphology: GaussianMorphology
 
     def __init__(self, sigma):
-        self.morphology = GaussianMorphology(jnp.zeros(2), sigma)
+        self.morphology = GaussianMorphology(sigma)
 
     def __call__(self):
         morph = self.morphology()

--- a/scarlet2/spectrum.py
+++ b/scarlet2/spectrum.py
@@ -2,12 +2,14 @@ import equinox as eqx
 import jax.numpy as jnp
 
 from . import Scenery
-from .bbox import Box
 from .module import Module
 
 
 class Spectrum(Module):
-    bbox: Box = eqx.field(static=True, init=False)
+
+    @property
+    def shape(self):
+        raise NotImplementedError
 
 
 class ArraySpectrum(Spectrum):
@@ -15,15 +17,19 @@ class ArraySpectrum(Spectrum):
 
     def __init__(self, data):
         self.data = data
-        self.bbox = Box(self.data.shape)
 
     def __call__(self):
         return self.data
 
+    @property
+    def shape(self):
+        return self.data.shape
+
+
 class StaticArraySpectrum(Spectrum):
-    data: jnp.array 
+    data: jnp.array
     channelindex: list = eqx.field(static=True)
-    
+
     def __init__(self, data, filters):
         try:
             frame = Scenery.scene.frame
@@ -31,32 +37,35 @@ class StaticArraySpectrum(Spectrum):
             print("Source can only be created within the context of a Scene")
             print("Use 'with Scene(frame) as scene: Source(...)'")
             raise
-        
-        self.data = data 
+
+        self.data = data
         self.channelindex = jnp.array([filters.index(c[0]) for c in frame.channels])
-        self.bbox = Box([len(self.channelindex)])
-    
+
     def __call__(self):
         return self.data[self.channelindex]
 
+    @property
+    def shape(self):
+        return len(self.channelindex),
+
+
 class TransientArraySpectrum(Spectrum):
-    data: jnp.array 
+    data: jnp.array
     _epochmultiplier: jnp.array = eqx.field(static=True)
-   
+
     def __init__(self, data, epochs):
         try:
             frame = Scenery.scene.frame
         except AttributeError:
             print("Source can only be created within the context of a Scene")
             print("Use 'with Scene(frame) as scene: Source(...)'")
-            raise 
+            raise
         self.data = data
         self._epochmultiplier = jnp.array([1.0 if c in epochs else 0.0 for c in frame.channels])
-        self.bbox = Box(self.data.shape)
 
-    def __call__(self): 
-        return jnp.multiply(self.data,self._epochmultiplier)
+    def __call__(self):
+        return jnp.multiply(self.data, self._epochmultiplier)
 
-
-
-    
+    @property
+    def shape(self):
+        return self.data.shape

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -28,14 +28,13 @@ def test_quickstart():
 
         for center in centers:
             center = jnp.array(center)
-            spectrum = init.pixel_spectrum(obs, center)
-            morph = init.adaptive_gaussian_morph(obs, center, min_corr=0.99) + 1e-6
+            try:
+                spectrum, morph = init.adaptive_morphology(obs, center, min_corr=0.99)
+            except ValueError:
+                spectrum = init.pixel_spectrum(obs, center)
+                morph = init.compact_morphology()
 
-            Source(
-                center,
-                ArraySpectrum(spectrum),
-                ArrayMorphology(morph)
-            )
+            Source(center, spectrum, morph)
 
     # fitting
     parameters = scene.make_parameters()
@@ -62,7 +61,6 @@ def test_quickstart():
     parameters += Parameter(p, name=f"spectrum:0", prior=prior)
     mcmc = scene_.sample(obs, parameters, num_samples=200, dense_mass=True, init_strategy=init_to_sample,
                          progress_bar=False)
-    mcmc.print_summary()
 
 if __name__ == "__main__":
     test_quickstart()


### PR DESCRIPTION
See discussion #71. This PR moves the `center` attribution from `Morphology` to `Component` (which now knows what to produce and where to place it). This means that `Morphology` and `Spectrum` now only have `shape` attributes, not `bbox` attributes (because they have no placement information).

In addition, the PR brings a simplification for the init procedures. The common init functions now return `ArraySpectrum` and `ArrayMorphology` instead of the ndarrays. So, they avoid the second line:
```python
spectrum = init.pixel_spectrum(obs, center)
spectrum = ArraySpectrum(spectrum)
```

If the old behavior is desired, run the init methods with `return_array=True`.

Finally, one can convert between different morphology implementation, e.g.
```python
img = <some 2d array>
morph = ArrayMorphology(img)

gaussian_morph = GaussianMorphology.from_image(img)
starlet_morph = StarletMorphology.from_image(morph())
morph_ = ArrayMorphology(starlet_morph())
```

Together this PR simplifies a number of internal operations, but the important part is for the user interface. A typical call now looks like this:
```python
with Scene(model_frame) as scene:
    try:
        spectrum, morph = init.adaptive_morphology(obs, center, min_corr=0.99)
    except ValueError:
        spectrum = init.pixel_spectrum(obs, center)
        morph = init.compact_morphology()
    Source(center, spectrum, morph)
```