### PR TITLE
Change of WCS in multiresolution renderer

### DIFF
--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord
 
 from .bbox import Box
 from .psf import PSF
+from .measure import get_scale
 
 
 class Frame(eqx.Module):
@@ -35,7 +36,8 @@ class Frame(eqx.Module):
     @property
     def pixel_size(self):
         if self.wcs is not None:
-            return get_pixel_size(get_affine(self.wcs)) * 60 * 60  # in arcsec
+            # return get_pixel_size(get_affine(self.wcs)) * 60 * 60  # in arcsec
+            return get_scale(self.wcs.wcs).mean() * 60 * 60 # in arcsec
         else:
             return 1
 

--- a/scarlet2/frame.py
+++ b/scarlet2/frame.py
@@ -7,8 +7,6 @@ from astropy.coordinates import SkyCoord
 
 from .bbox import Box
 from .psf import PSF
-from .measure import get_scale
-
 
 class Frame(eqx.Module):
     bbox: Box
@@ -37,7 +35,7 @@ class Frame(eqx.Module):
     def pixel_size(self):
         if self.wcs is not None:
             # return get_pixel_size(get_affine(self.wcs)) * 60 * 60  # in arcsec
-            return get_scale(self.wcs.wcs).mean() * 60 * 60 # in arcsec
+            return get_scale(self.wcs).mean() * 60 * 60 # in arcsec
         else:
             return 1
 
@@ -317,3 +315,46 @@ def get_pixel_size(model_affine):
         * np.abs(model_affine[1, 1] - model_affine[0, 1] * model_affine[1, 0])
     )
     return pix
+
+def get_scale(wcs):
+    """
+    Return WCS axis scales in deg/pixel
+    """
+    model_affine = get_affine(wcs)
+    c1 = (model_affine[0,:2]**2).sum()**0.5
+    c2 = (model_affine[1,:2]**2).sum()**0.5
+    return jnp.array([c1, c2])
+    
+def get_angle(wcs):
+    """
+    Return WCS rotation angle in rad
+    """
+    model_affine = get_affine(wcs)
+    c = get_scale(wcs)
+    c = c.reshape([c.shape[-1],1])
+    R = model_affine[:2, :2] / c # removing the scaling factors from the pc
+
+    if R[0,0]==0.:
+        return jnp.arcsin(R[0,1])
+    else:
+        return jnp.arctan(R[0,1]/R[0,0])
+
+def get_sign(wcs):
+    """
+    Return WCS flip signs
+    """
+    model_affine = get_affine(wcs)
+    c = get_scale(wcs)
+    c = c.reshape([c.shape[-1],1])
+    R = model_affine[:2, :2] / c # removing the absolute scaling factors from the pc
+
+    if R[0,0]==0.:
+        phi = jnp.arcsin(R[0,1])
+    else:
+        phi = jnp.arctan(R[0,1]/R[0,0])
+    
+    R_inv = jnp.array([[jnp.cos(phi), -jnp.sin(phi)],
+                    [jnp.sin(phi), jnp.cos(phi)]])
+    
+    R = R_inv @ R
+    return jnp.diag(R)

--- a/scarlet2/interpolation.py
+++ b/scarlet2/interpolation.py
@@ -294,10 +294,6 @@ def resample_ops(kimage, shape_in, shape_out, res_in, res_out, phi=None, flip_si
         b_shape = kcoords_out.shape
         kcoords_out = (R @ kcoords_out.reshape((-1, 2)).T).T.reshape((b_shape))
 
-    # TODO: Apply flip on rotation if any
-    # if flip_sign is not None:
-    #     kcoords_out = kcoords_out*flip_sign.reshape((2,1,1))
-
     k_resampled = jax.vmap(resample_hermitian, in_axes=(0,None,None,None,None))(
         kimage,
         kcoords_out,
@@ -306,9 +302,6 @@ def resample_ops(kimage, shape_in, shape_out, res_in, res_out, phi=None, flip_si
         interpolant
         )
     
-    # TODO: Apply flip on rotation if any
-    # k_resampled *= flip_sign.prod()
-
     kx = jnp.linspace(0, jnp.pi, shape_out//2 + 1) * res_in/res_out
     ky = jnp.linspace(-jnp.pi, jnp.pi, shape_out)
     coords = jnp.stack(jnp.meshgrid(kx, ky),-1) / 2 / jnp.pi

--- a/scarlet2/measure.py
+++ b/scarlet2/measure.py
@@ -318,23 +318,25 @@ class Moments(dict):
         wcs_in: astropy.wcs.Wcsprm
         wcs_out: astropy.wcs.Wcsprm
         """
-            
-        # Rescale moments (amplitude rescaling)
-        scale_in = get_scale(wcs_in) * 60**2 # arcsec
-        scale_out = get_scale(wcs_out) * 60**2 # arcsec
-        c = jnp.array(scale_in) / jnp.array(scale_out)
-        self.resize(c)
 
-        # Rotate moments
-        phi_in = get_angle(wcs_in)
-        phi_out = get_angle(wcs_out)
-        phi = (phi_out - phi_in)/jnp.pi*180
-        self.rotate(phi*u.deg)
+        if (wcs_in is not None) and (wcs_out is not None):
 
-        # Flip moments if WCSs don't share the same convention
-        sign_in = get_sign(wcs_in)
-        sign_out = get_sign(wcs_out)
-        self.resize(sign_in*sign_out)
+            # Rescale moments (amplitude rescaling)
+            scale_in = get_scale(wcs_in) * 60**2 # arcsec
+            scale_out = get_scale(wcs_out) * 60**2 # arcsec
+            c = jnp.array(scale_in) / jnp.array(scale_out)
+            self.resize(c)
+
+            # Rotate moments
+            phi_in = get_angle(wcs_in)
+            phi_out = get_angle(wcs_out)
+            phi = (phi_out - phi_in)/jnp.pi*180
+            self.rotate(phi*u.deg)
+
+            # Flip moments if WCSs don't share the same convention
+            sign_in = get_sign(wcs_in)
+            sign_out = get_sign(wcs_out)
+            self.resize(sign_in*sign_out)
 
 
 # adapted from  https://github.com/pmelchior/shapelens/blob/src/DEIMOS.cc

--- a/scarlet2/measure.py
+++ b/scarlet2/measure.py
@@ -4,7 +4,7 @@ import math
 import astropy.units as u
 
 from .source import Component
-
+from .frame import get_scale, get_angle, get_sign
 
 def max_pixel(component):
     """Determine pixel with maximum value
@@ -324,37 +324,6 @@ def binomial(n, k):
         result *= n - i + 1
         result //= i
     return result
-
-def get_scale(wcs):
-    c1 = (wcs.pc[0,:2]**2).sum()**0.5
-    c2 = (wcs.pc[1,:2]**2).sum()**0.5
-    return jnp.array([c1, c2])
-    
-def get_angle(wcs):
-    c = get_scale(wcs)
-    c = c.reshape([c.shape[-1],1])
-    R = wcs.pc[:2, :2] / c # removing the scaling factors from the pc
-
-    if R[0,0]==0.:
-        return jnp.arcsin(R[0,1])
-    else:
-        return jnp.arctan(R[0,1]/R[0,0])
-
-def get_sign(wcs):
-    c = get_scale(wcs)
-    c = c.reshape([c.shape[-1],1])
-    R = wcs.pc[:2, :2] / c # removing the absolute scaling factors from the pc
-
-    if R[0,0]==0.:
-        phi = jnp.arcsin(R[0,1])
-    else:
-        phi = jnp.arctan(R[0,1]/R[0,0])
-    
-    R_inv = jnp.array([[jnp.cos(phi), -jnp.sin(phi)],
-                    [jnp.sin(phi), jnp.cos(phi)]])
-    
-    R = R_inv @ R
-    return jnp.diag(R)
 
 
 

--- a/scarlet2/measure.py
+++ b/scarlet2/measure.py
@@ -358,16 +358,27 @@ def get_angle(wcs):
     c = get_scale(wcs)
     c = c.reshape([c.shape[-1],1])
     R = wcs.pc[:2, :2] / c # removing the scaling factors from the pc
-    return jnp.arcsin(jnp.abs(R[0,1])) # R[0,1]=sin(phi) should be positive
+
+    if R[0,0]==0.:
+        return jnp.arcsin(R[0,1])
+    else:
+        return jnp.arctan(R[0,1]/R[0,0])
 
 def get_sign(wcs):
     c = get_scale(wcs)
     c = c.reshape([c.shape[-1],1])
     R = wcs.pc[:2, :2] / c # removing the absolute scaling factors from the pc
 
-    phi = jnp.arcsin(jnp.abs(R[0,1])) # R[0,1]=sin(phi) should be positive
+    if R[0,0]==0.:
+        phi = jnp.arcsin(R[0,1])
+    else:
+        phi = jnp.arctan(R[0,1]/R[0,0])
+    
     R_inv = jnp.array([[jnp.cos(phi), -jnp.sin(phi)],
                     [jnp.sin(phi), jnp.cos(phi)]])
     
     R = R_inv @ R
     return jnp.diag(R)
+
+
+

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -182,16 +182,16 @@ class ResamplingMultiresRenderer(Renderer):
         object.__setattr__(self, "res_out", obs_frame.pixel_size)
 
         # Extract rotation angle between WCSs using jacobian matrices
-        angle_in = get_angle(model_frame.wcs.wcs)
-        angle_out = get_angle(obs_frame.wcs.wcs)
+        angle_in = get_angle(model_frame.wcs)
+        angle_out = get_angle(obs_frame.wcs)
         if angle_out - angle_in == 0:
             object.__setattr__(self, "rotation_angle", None)
         else:
             object.__setattr__(self, "rotation_angle", angle_out - angle_in)
         
         # Get flip sign between WCSs using jacobian matrices
-        sign_in = get_sign(model_frame.wcs.wcs)
-        sign_out = get_sign(obs_frame.wcs.wcs)
+        sign_in = get_sign(model_frame.wcs)
+        sign_out = get_sign(obs_frame.wcs)
         object.__setattr__(self, "flip_sign", sign_in*sign_out)
 
     def __call__(self, kimages, key=None):

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -184,8 +184,11 @@ class ResamplingMultiresRenderer(Renderer):
         # Extract rotation angle between WCSs using jacobian matrices
         angle_in = get_angle(model_frame.wcs.wcs)
         angle_out = get_angle(obs_frame.wcs.wcs)
-        object.__setattr__(self, "rotation_angle", angle_out - angle_in )
-
+        if angle_out - angle_in == 0:
+            object.__setattr__(self, "rotation_angle", None)
+        else:
+            object.__setattr__(self, "rotation_angle", angle_out - angle_in)
+        
         # Get flip sign between WCSs using jacobian matrices
         sign_in = get_sign(model_frame.wcs.wcs)
         sign_out = get_sign(obs_frame.wcs.wcs)

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -192,6 +192,9 @@ class ResamplingMultiresRenderer(Renderer):
         # Get flip sign between WCSs using jacobian matrices
         sign_in = get_sign(model_frame.wcs)
         sign_out = get_sign(obs_frame.wcs)
+        if (sign_in != sign_out).any():
+            raise ValueError("model and observation WCSs have different sign conventions, which is not yet handled by scarlet2")
+
         object.__setattr__(self, "flip_sign", sign_in*sign_out)
 
     def __call__(self, kimages, key=None):

--- a/tests/test_moments.py
+++ b/tests/test_moments.py
@@ -87,7 +87,7 @@ def test_wcs_transfer_moments():
     im_hst = jnp.rot90(morph())
 
     # Generate the same image seen from HSC
-    h = (get_scale(wcs_hst.wcs) / get_scale(wcs_hsc.wcs)).mean()
+    h = (get_scale(wcs_hst) / get_scale(wcs_hsc)).mean()
     T1 = T0 * h 
     ellipticity1 = jnp.array((0.3,0.5))
     morph1 = GaussianMorphology(size=T1, ellipticity=ellipticity1, shape=im_hst.shape)
@@ -100,7 +100,7 @@ def test_wcs_transfer_moments():
     g1 = scarlet2.measure.moments(im_hsc)
 
     # Transfer moments from HST to HSC frame
-    g0.transfer(wcs_hst.wcs, wcs_hsc.wcs)
+    g0.transfer(wcs_hst, wcs_hsc)
 
     # Check that size and ellipticity are conserved
     assert_allclose(g1.size, g0.size, rtol=1e-3)
@@ -129,7 +129,7 @@ def test_wcs_transfer_w_flip_moments():
     im_hst = jnp.rot90(morph())[:,::-1]
 
     # Generate the same image seen from HSC
-    h = (get_scale(wcs_hst.wcs) / get_scale(wcs_hsc.wcs)).mean()
+    h = (get_scale(wcs_hst) / get_scale(wcs_hsc)).mean()
     T1 = T0 * h 
     ellipticity1 = jnp.array((0.3,0.5))
     morph1 = GaussianMorphology(size=T1, ellipticity=ellipticity1, shape=im_hst.shape)
@@ -142,7 +142,7 @@ def test_wcs_transfer_w_flip_moments():
     g1 = scarlet2.measure.moments(im_hsc)
 
     # Transfer moments from HST to HSC frame
-    g0.transfer(wcs_hst.wcs, wcs_hsc.wcs)
+    g0.transfer(wcs_hst, wcs_hsc)
 
     # Check that size and ellipticity are conserved
     assert_allclose(g1.size, g0.size, rtol=1e-3)
@@ -170,7 +170,7 @@ def test_wcs_transfer_moments_multichannels():
     im_hst = vmap(jnp.rot90)(im_hst)
 
     # Generate the same image seen from HSC
-    h = (get_scale(wcs_hst.wcs) / get_scale(wcs_hsc.wcs)).mean()
+    h = (get_scale(wcs_hst) / get_scale(wcs_hsc)).mean()
     T1 = T0 * h 
     ellipticity1 = jnp.array((0.3,0.5))
     morph1 = GaussianMorphology(size=T1, ellipticity=ellipticity1, shape=im_hst.shape)
@@ -183,7 +183,7 @@ def test_wcs_transfer_moments_multichannels():
     g1 = scarlet2.measure.moments(im_hsc)
 
     # Transfer moments from HST to HSC frame
-    g0.transfer(wcs_hst.wcs, wcs_hsc.wcs)
+    g0.transfer(wcs_hst, wcs_hsc)
     # Check that size and ellipticity are conserved
     assert_allclose(jnp.repeat(g1.size, nc), g0.size, rtol=1e-3)
     assert_allclose(jnp.repeat(g1.ellipticity[:,None], nc, 1), g0.ellipticity, rtol=1e-2)

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -29,7 +29,7 @@ def test_quickstart():
         for center in centers:
             center = jnp.array(center)
             try:
-                spectrum, morph = init.make_bbox(obs, center, min_corr=0.99)
+                spectrum, morph = init.from_gaussian_moments(obs, center, min_corr=0.99)
             except ValueError:
                 spectrum = init.pixel_spectrum(obs, center)
                 morph = init.compact_morphology()


### PR DESCRIPTION
This PR solves #75. So far the multiresolution renderer only worked for aligned WCSs with a scale difference. Now, the code detects WCSs rotations in `obs.match()` and handles them in `obs.render()`.