### PR TITLE
fixes #100

### DIFF
--- a/scarlet2/module.py
+++ b/scarlet2/module.py
@@ -1,11 +1,11 @@
+import astropy.units as u
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import varname
-
 from astropy.coordinates import SkyCoord
-import astropy.units as u
+
 
 class Module(eqx.Module):
 
@@ -47,8 +47,10 @@ class Parameter:
             self.name = name
         self.node = node
 
+        if prior is not None and constraint is not None:
+            raise AttributeError(f"Cannot set prior and constraint on the same parameter {self.name}!")
+
         self.constraint = constraint
-        
         self.prior = prior
         self.stepsize = stepsize
     


### PR DESCRIPTION
Since #72, the `bbox` attribute is in `Source`, not in morphology. This PR fixes `plot.sources`, which used the outdated call.

It also corrects the plotting of a single source in the frame of the observation, which should behave as if the entire scene only had this one source in it. An earlier implementation only (approximately) worked for simple renderers.