### PR TITLE
Flux conservation in `Moments.transfer`

### DIFF
--- a/scarlet2/measure.py
+++ b/scarlet2/measure.py
@@ -365,6 +365,8 @@ class Moments(dict):
         None
         """
 
+        flux_in = self[0,0]
+
         if (wcs_in is not None) and (wcs_out is not None):
             # Rescale moments (amplitude rescaling)
             scale_in = get_scale(wcs_in) * 60 ** 2  # arcsec
@@ -383,7 +385,11 @@ class Moments(dict):
             sign_out = get_sign(wcs_out)
             self.resize(sign_in * sign_out)
 
-
+            flux_out = self[0,0]
+            
+            for key in self.keys():
+                self[key]  /= flux_out/flux_in
+                
 # def moments(component, N=2, center=None, weight=None):
 #    return Moments(component, N=N, center=center, weight=weight)
 


### PR DESCRIPTION
This small PR fixes flux issues in mutlresolution initialization, and moments transfer from one resolution to another. We now normalize each moment by the flux ratio at the end of the `Moments.transfer` method.

This issue was identified when initializing a model with HST resolution from an HSC observation, returning

![image](https://github.com/user-attachments/assets/3554f54f-dadd-45d9-8169-74f268a67217)

which now returns

![image](https://github.com/user-attachments/assets/a4773003-6746-4781-9b85-b3e6fab44ddd)
 