### PR TITLE
Handles no channel axis in psf, fixes #123

### DIFF
--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -41,7 +41,7 @@ class Observation(Module):
         Parameters
         ----------
         model: array
-            The (pre-rendered) predicted data cube, typically from evaluateing :py:class:`~scarlet2.Scene`
+            The (pre-rendered) predicted data cube, typically from evaluating :py:class:`~scarlet2.Scene`
 
         Returns
         -------
@@ -56,7 +56,7 @@ class Observation(Module):
         Parameters
         ----------
         model: array
-            The (pre-rendered) predicted data cube, typically from evaluateing :py:class:`~scarlet2.Scene`
+            The (pre-rendered) predicted data cube, typically from evaluating :py:class:`~scarlet2.Scene`
 
         Returns
         -------

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -169,11 +169,15 @@ class MultiresolutionRenderer(Renderer):
 
         # create PSF model
         psf_model = model_frame.psf()
+        if len(psf_model.shape)==2:
+            psf_model = psf_model[None,...]
 
         if len(psf_model.shape) == 2:  # only one image for all bands
             psf_model = jnp.tile(psf_model, (obs_frame.bbox.shape[0], 1, 1))
 
         psf_obs = obs_frame.psf()
+        if len(psf_obs.shape)==2:
+            psf_obs = psf_obs[None,...]
 
         fft_shape_model_im = good_fft_size(padding * max(model_frame.bbox.shape))
         fft_shape_model_psf = good_fft_size(padding * max(psf_model.shape))


### PR DESCRIPTION
This PR adds a channel axis in the observation and model psf arrays in the `MultiresolutionRenderer`, which is necessary for the vmap operation
https://github.com/pmelchior/scarlet2/blob/1221197fde38c91ce4b9627a7baf0354da00a490/scarlet2/renderer.py#L251

This case is now tested in `test_renderer.py`. 

Additionnally, I reintroduced the `assert` functions that were removed in commit 3a9c335