### PR TITLE
Calling nn priors with batches

### DIFF
--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -8,7 +8,9 @@ from .frame import Frame
 from .module import Module, Parameters
 from .renderer import ChannelRenderer
 from .spectrum import ArraySpectrum
+from .nn import ScorePrior, pad_fwd, pad_back
 
+from collections import defaultdict
 
 class Scene(Module):
     """Model of the celestial scene
@@ -421,10 +423,19 @@ def _make_step(model, observations, parameters, optim, opt_state, filter_spec=No
         log_like = sum(obs.log_likelihood(pred) for obs in observations)
 
         param_values = model.get(parameters)
-        log_prior = sum(param.prior.log_prob(value)
-                        for param, value in zip(parameters, param_values)
-                        if param.prior is not None
-                        )
+
+        log_prior = 0
+
+        # Gather parameters with the same ScorePrior for parallel evaluation
+        grouped = defaultdict(list) 
+        for param, value in zip(parameters, param_values):
+            if isinstance(param.prior, ScorePrior):
+                grouped[param.prior].append(pad_fwd(value, param.prior.shape))
+            elif param.prior is not None:
+                log_prior += param.prior.log_prob(value) 
+
+        log_prior += sum(jax.vmap(prior.log_prob)(jnp.stack(arr_list, axis=0)) for prior, arr_list in grouped.items())
+    
         return -(log_like + log_prior)
 
     if filter_spec is None:

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -430,12 +430,12 @@ def _make_step(model, observations, parameters, optim, opt_state, filter_spec=No
         grouped = defaultdict(list) 
         for param, value in zip(parameters, param_values):
             if isinstance(param.prior, ScorePrior):
-                grouped[param.prior].append(pad_fwd(value, param.prior.shape))
+                grouped[param.prior].append(pad_fwd(value, param.prior._model.shape)[0])
             elif param.prior is not None:
                 log_prior += param.prior.log_prob(value) 
 
-        log_prior += sum(jax.vmap(prior.log_prob)(jnp.stack(arr_list, axis=0)) for prior, arr_list in grouped.items())
-    
+        log_prior += sum(sum(jax.vmap(prior.log_prob)(jnp.stack(arr_list, axis=0)) for prior, arr_list in grouped.items()))
+
         return -(log_like + log_prior)
 
     if filter_spec is None:

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -8,7 +8,7 @@ from .frame import Frame
 from .module import Module, Parameters
 from .renderer import ChannelRenderer
 from .spectrum import ArraySpectrum
-from .nn import ScorePrior, pad_fwd, pad_back
+from .nn import ScorePrior, pad_fwd
 
 from collections import defaultdict
 

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -434,7 +434,8 @@ def _make_step(model, observations, parameters, optim, opt_state, filter_spec=No
             elif param.prior is not None:
                 log_prior += param.prior.log_prob(value) 
 
-        log_prior += sum(sum(jax.vmap(prior.log_prob)(jnp.stack(arr_list, axis=0)) for prior, arr_list in grouped.items()))
+        if len(grouped) > 0:
+            log_prior += sum(sum(jax.vmap(prior.log_prob)(jnp.stack(arr_list, axis=0)) for prior, arr_list in grouped.items()))
 
         return -(log_like + log_prior)
 


### PR DESCRIPTION
This PR factorizes the log prob evaluation for nn priors, as described in #103 . It groups parameters that share the same model in their prior and stacks them to evaluate the log probability in parallel.

In the [priors.ipynb](https://github.com/pmelchior/scarlet2/blob/main/docs/howto/priors.ipynb) tutorial
- on CPU, fitting time reduces from `00:42` to `00:30` (ran with `1_000` iterations)
- on GPU, fitting time reduces from `01:20` to `01:13` (ran with`10_000` iterations)

This is not an big difference, but only a couple of sources are involved