### PR TITLE
removes static fields; closes #121

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "file = jnp.load(os.path.join(data_path, \"hsc_cosmos_35.npz\"))\n",
     "data = jnp.asarray(file[\"images\"])\n",
-    "channels = list(file['filters'])\n",
+    "channels = [str(f) for f in file['filters']]\n",
     "centers = jnp.array([(src['y'], src['x']) for src in file[\"catalog\"]])  # Note: y/x convention!\n",
     "weights = jnp.asarray(1 / file[\"variance\"])\n",
     "psf = jnp.asarray(file[\"psfs\"])"

--- a/docs/howto/priors.ipynb
+++ b/docs/howto/priors.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "file = jnp.load(os.path.join(data_path, \"hsc_cosmos_35.npz\"))\n",
     "data = jnp.asarray(file[\"images\"])\n",
-    "channels = list(file['filters'])\n",
+    "channels = [str(f) for f in file['filters']]\n",
     "centers = jnp.array([(src['y'], src['x']) for src in file[\"catalog\"]])\n",
     "weights = jnp.asarray(1 / file[\"variance\"])\n",
     "psf = jnp.asarray(file[\"psfs\"])\n",

--- a/docs/howto/sampling.ipynb
+++ b/docs/howto/sampling.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "import os\n",
+    "\n",
     "\n",
     "# Import Packages and setup\n",
     "import jax.numpy as jnp\n",
@@ -34,37 +34,6 @@
     "\n",
     "We need to create the {py:class}`~scarlet2.Observation` because it contains the {py:func}`~scarlet2.Observation.log_likelihood` method we need for the posterior:"
    ]
-  },
-  {
-   "cell_type": "code",
-   "source": [
-    "# load the data\n",
-    "from scarlet2.utils import import_scarlet_test_data\n",
-    "\n",
-    "import_scarlet_test_data()\n",
-    "from scarlet_test_data import data_path\n",
-    "\n",
-    "file = jnp.load(os.path.join(data_path, \"hsc_cosmos_35.npz\"))\n",
-    "data = jnp.asarray(file[\"images\"])\n",
-    "channels = list(file['filters'])\n",
-    "centers = jnp.array([(src['y'], src['x']) for src in file[\"catalog\"]])\n",
-    "weights = jnp.asarray(1 / file[\"variance\"])\n",
-    "psf = jnp.asarray(file[\"psfs\"])\n",
-    "\n",
-    "# create the observation\n",
-    "model_psf = GaussianPSF(0.7)\n",
-    "model_frame = Frame(Box(data.shape), psf=model_psf, channels=channels)\n",
-    "obs = Observation(data,\n",
-    "                  weights,\n",
-    "                  psf=ArrayPSF(psf),\n",
-    "                  channels=channels,\n",
-    "                  ).match(model_frame)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -276,9 +245,9 @@
   {
    "cell_type": "code",
    "source": [
-    "print(f\"------- {channels}\")\n",
-    "for scene in scenes:\n",
-    "    print(f\"Fluxes: {measure.flux(scene.sources[0])}\")"
+    "print(f\"-------------- {channels}\")\n",
+    "for i, scene in enumerate(scenes):\n",
+    "    print(f\"Flux Sample {i}: {measure.flux(scene.sources[0])}\")"
    ],
    "metadata": {
     "collapsed": false

--- a/scarlet2/morphology.py
+++ b/scarlet2/morphology.py
@@ -27,7 +27,7 @@ class ProfileMorphology(Morphology):
     """
     ellipticity: (None, jnp.array)
     """Ellipticity of the profile"""
-    _shape: tuple = eqx.field(static=True, init=False, repr=False)
+    _shape: tuple = eqx.field(init=False, repr=False)
 
     def __init__(self, size, ellipticity=None, shape=None):
         if isinstance(size, u.Quantity):
@@ -207,9 +207,9 @@ class StarletMorphology(Morphology):
     """
     coeffs: jnp.ndarray
     """Starlet coefficients"""
-    l1_thresh: float = eqx.field(default=1e-2, static=True)
+    l1_thresh: float
     """L1 threshold for coefficient to create sparse representation"""
-    positive: bool = eqx.field(default=True, static=True)
+    positive: bool
     """Whether the coefficients are restricted to non-negative values"""
 
     def __call__(self, **kwargs):

--- a/scarlet2/observation.py
+++ b/scarlet2/observation.py
@@ -19,10 +19,9 @@ class Observation(Module):
     """Observed data"""
     weights: jnp.ndarray
     """Statistical weights (usually inverse variance) for :py:meth:`log_likelihood`"""
-    frame: Frame = eqx.field(static=True)
+    frame: Frame
     """Metadata to describe what view of the sky `data` amounts to"""
-    # TODO: requires static, otherwise quickstart test aborts wiht "TypeError: unhashable type: 'slice'"
-    renderer: (Renderer, eqx.nn.Sequential) = eqx.field(static=True)
+    renderer: (Renderer, eqx.nn.Sequential)
     """Renderer to translate from the model frame the observation frame"""
 
     def __init__(self, data, weights, psf=None, wcs=None, channels=None, renderer=None):

--- a/scarlet2/renderer.py
+++ b/scarlet2/renderer.py
@@ -101,6 +101,7 @@ class ConvolutionRenderer(Renderer):
 
     The convolution is performed in Fourier space and applies the difference kernel between model PSF and observed PSF.
     """
+    _diff_kernel_fft: jnp.array = eqx.field(init=False, repr=False)
 
     def __init__(self, model_frame, obs_frame):
         """Initialize convolution renderer with difference kernel between `model_frame` and `obs_frame`
@@ -130,7 +131,7 @@ class ConvolutionRenderer(Renderer):
             fft_shape=fft_shape,
             return_fft=True,
         )
-        object.__setattr__(self, "_diff_kernel_fft", diff_kernel_fft)
+        self._diff_kernel_fft = diff_kernel_fft
 
     def __call__(self, model, key=None):
         return convolve(model, self._diff_kernel_fft, axes=(-2, -1))

--- a/scarlet2/scene.py
+++ b/scarlet2/scene.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
@@ -6,10 +8,9 @@ from . import Scenery
 from .bbox import overlap_slices
 from .frame import Frame
 from .module import Module, Parameters
-from .renderer import ChannelRenderer
 from .nn import ScorePrior, pad_fwd
+from .renderer import ChannelRenderer
 
-from collections import defaultdict
 
 class Scene(Module):
     """Model of the celestial scene
@@ -19,7 +20,7 @@ class Scene(Module):
     any method implemented in jax, but this class provides the :py:func:`fit` and :py:func:`sample` methods as built-in
     solutions.
     """
-    frame: Frame = eqx.field(static=True)
+    frame: Frame
     """Portion of the sky represented by this model"""
     sources: list
     """List of :py:class:`~scarlet2.Source` comprised in this model"""

--- a/scarlet2/source.py
+++ b/scarlet2/source.py
@@ -25,7 +25,7 @@ class Component(Module):
     """Spectrum model"""
     morphology: (jnp.array, Morphology)
     """Morphology model"""
-    bbox: Box = eqx.field(static=True, init=False)
+    bbox: Box = eqx.field(init=False)
     """Bounding box of the model, in pixel coordinates of the model frame"""
 
     def __init__(self, center, spectrum, morphology):
@@ -88,7 +88,7 @@ class Source(Component):
     """
     components: list
     """List of components in this source"""
-    component_ops: list = eqx.field(static=True)
+    component_ops: list
     """List of operators to combine `components` for the final model"""
 
     def __init__(self, center, spectrum, morphology):

--- a/scarlet2/spectrum.py
+++ b/scarlet2/spectrum.py
@@ -1,4 +1,3 @@
-import equinox as eqx
 import jax.numpy as jnp
 
 from . import Scenery
@@ -29,7 +28,7 @@ class StaticArraySpectrum(Spectrum):
     """
     bands: list
     """Identifier for the list of unique bands in the model frame channels"""
-    _channelindex: jnp.array = eqx.field(static=True)
+    _channelindex: jnp.array
 
     def __init__(self, data, bands, band_selector=lambda channel: channel[0]):
         """
@@ -91,7 +90,7 @@ class TransientArraySpectrum(Spectrum):
     """
     epochs: list
     """Identifier for the list of active epochs. If set to `None`, all epochs are considered active"""
-    _epochmultiplier: jnp.array = eqx.field(static=True)
+    _epochmultiplier: jnp.array
 
     def __init__(self, data, epochs=None, epoch_selector=lambda channel: channel[1]):
         """

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -13,7 +13,7 @@ from scarlet_test_data import data_path
 def test_quickstart():
     file = jnp.load(os.path.join(data_path, "hsc_cosmos_35.npz"))
     data = jnp.asarray(file["images"])
-    channels = list(file['filters'])
+    channels = [str(f) for f in file['filters']]
     centers = [(src['y'], src['x']) for src in file["catalog"]]  # Note: y/x convention!
     weights = jnp.asarray(1 / file["variance"])
     psf = jnp.asarray(file["psfs"])

--- a/tests/test_save_output.py
+++ b/tests/test_save_output.py
@@ -63,8 +63,12 @@ def test_save_output():
     loaded = jax.tree_util.tree_leaves(scene_loaded)
     status = True
     for leaf_saved, leaf_loaded in zip(saved, loaded):
-        if (leaf_saved != leaf_loaded).all():
-            status = False
+        if hasattr(leaf_saved, "__iter__"):
+            if (leaf_saved != leaf_loaded).all():
+                status = False
+        else:
+            if leaf_saved != leaf_loaded:
+                status = False
         
     print(f"saved == loaded: {status}")
     assert status == True, "Loaded leaves not identical to original"


### PR DESCRIPTION
To silence the jax warnings and to get prevent it from interfering with the jit compilation (#120), this PR removes all occurrences of `static`. There should be no user-facing consequences, but I wasn't able to check the transient case without a test case.

One problem I kept having was due from the `channel` parameter in the quickstart case, because they are saved as `numpy.str`, which jax does not understand. Thus, we need to convert to a list of standard python string.