### PR TITLE
Scaffolding code for validation

### DIFF
--- a/src/scarlet2/__init__.py
+++ b/src/scarlet2/__init__.py
@@ -30,7 +30,7 @@ from .psf import PSF, ArrayPSF, GaussianPSF
 from .scene import Scene
 from .source import Component, DustComponent, PointSource, Source
 from .spectrum import Spectrum, StaticArraySpectrum, TransientArraySpectrum
-from .validation import check_fit, check_observation, check_scene
+from .validation import check_fit, check_observation, check_scene, check_source
 from .wavelets import Starlet
 
 # for * imports and docs
@@ -63,7 +63,8 @@ __all__ = [
     "StaticArraySpectrum",
     "TransientArraySpectrum",
     "Starlet",
+    "check_fit",
     "check_observation",
     "check_scene",
-    "check_fit",
+    "check_source",
 ]

--- a/src/scarlet2/__init__.py
+++ b/src/scarlet2/__init__.py
@@ -30,6 +30,7 @@ from .psf import PSF, ArrayPSF, GaussianPSF
 from .scene import Scene
 from .source import Component, DustComponent, PointSource, Source
 from .spectrum import Spectrum, StaticArraySpectrum, TransientArraySpectrum
+from .validation import check_fit, check_observation, check_scene
 from .wavelets import Starlet
 
 # for * imports and docs
@@ -62,4 +63,7 @@ __all__ = [
     "StaticArraySpectrum",
     "TransientArraySpectrum",
     "Starlet",
+    "check_observation",
+    "check_scene",
+    "check_fit",
 ]

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -14,7 +14,7 @@ from .renderer import (
     NoRenderer,
     Renderer,
 )
-from .validation import ValidationError, ValidationMethodCollector
+from .validation_utils import ValidationError, ValidationMethodCollector
 
 
 class Observation(Module):
@@ -46,7 +46,6 @@ class Observation(Module):
 
             validation_errors = check_observation(self)
             if validation_errors:
-                #! We can raise this as a ValueError or assign it to self.validation_errors
                 raise ValueError(
                     "Observation validation failed with the following errors:\n"
                     + "\n".join(str(error) for error in validation_errors)

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -25,8 +25,12 @@ class Observation(Module):
     """Metadata to describe what view of the sky `data` amounts to"""
     renderer: (Renderer, eqx.nn.Sequential) = eqx.field(static=True)
     """Renderer to translate from the model frame the observation frame"""
+    check_observation: bool = eqx.field(static=True, default=False)
+    """Whether to validation checks on the observation object. Default is False."""
 
-    def __init__(self, data, weights, psf=None, wcs=None, channels=None, renderer=None):
+    def __init__(
+        self, data, weights, psf=None, wcs=None, channels=None, renderer=None, check_observation=False
+    ):
         self.data = data
         self.weights = weights
         if channels is None:
@@ -35,6 +39,12 @@ class Observation(Module):
         if renderer is None:
             renderer = NoRenderer()
         self.renderer = renderer
+        self.check_observation = check_observation
+
+        if self.check_observation:
+            from .validation import check_observation
+
+            check_observation(self)
 
     def render(self, model):
         """Render `model` in the frame of this observation

--- a/src/scarlet2/scene.py
+++ b/src/scarlet2/scene.py
@@ -25,18 +25,13 @@ class Scene(Module):
     """Portion of the sky represented by this model"""
     sources: list
     """List of :py:class:`~scarlet2.Source` comprised in this model"""
-    check_scene: bool = eqx.field(static=True, default=False)
-    """Whether to run validation checks on the scene after initialization. Default is `False`."""
 
-    def __init__(self, frame, check_scene=False):
+    def __init__(self, frame):
         """
         Parameters
         ----------
         frame: `Frame`
             Portion of the sky represented by this model
-        check_scene: bool, optional
-            Whether to run validation checks on the scene after initialization.
-            Default is `False`.
 
         Examples
         --------
@@ -59,7 +54,6 @@ class Scene(Module):
         """
         self.frame = frame
         self.sources = list()
-        self.check_scene = check_scene
 
     def __call__(self):
         """What to run when the scene is called"""
@@ -102,10 +96,6 @@ class Scene(Module):
 
     def __exit__(self, exc_type, exc_value, traceback):
         Scenery.scene = None
-        if self.check_scene:
-            from .validation import check_scene
-
-            check_scene(self)
 
     def sample(
         self, observations, parameters, seed=0, num_warmup=100, num_samples=200, progress_bar=True, **kwargs

--- a/src/scarlet2/scene.py
+++ b/src/scarlet2/scene.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import Optional
 
 import equinox as eqx
 import jax
@@ -9,6 +10,7 @@ from .bbox import overlap_slices
 from .frame import Frame
 from .module import Module, Parameters
 from .renderer import ChannelRenderer
+from .validation import ValidationError, ValidationMethodCollector
 
 
 class Scene(Module):
@@ -339,7 +341,12 @@ class Scene(Module):
         if check_fit:
             from .validation import check_fit
 
-            check_fit(returned_scene)
+            validation_errors = check_fit(returned_scene)
+            if validation_errors:
+                raise ValueError(
+                    "Fit validation failed. The following errors were found:\n"
+                    + "\n".join(str(error) for error in validation_errors)
+                )
 
         return returned_scene
 
@@ -508,3 +515,25 @@ def _make_step(model, observations, parameters, optim, opt_state, filter_spec=No
     convergence = jax.tree_util.tree_map(lambda x, dx: norm(x, dx), *(model, updates))
 
     return model_, loss, opt_state, convergence
+
+
+class FitValidator(metaclass=ValidationMethodCollector):
+    """A class containing all of the validation checks for a Scene objects after
+    calling `.fit()`.
+
+    Note that the metaclass is defined as `MethodCollector`, which collects all
+    validation methods in this class into a single class attribute list called
+    `validation_checks`. This allows for easy iteration over all checks."""
+
+    def __init__(self, scene: Scene):
+        self.scene = scene
+
+    def check_fit_example(self) -> Optional[ValidationError]:
+        """Check that the fit was successful.
+
+        Returns
+        -------
+        ValidationError or None
+            Returns a ValidationError if the check fails, otherwise None.
+        """
+        return None

--- a/src/scarlet2/scene.py
+++ b/src/scarlet2/scene.py
@@ -10,7 +10,7 @@ from .bbox import overlap_slices
 from .frame import Frame
 from .module import Module, Parameters
 from .renderer import ChannelRenderer
-from .validation import ValidationError, ValidationMethodCollector
+from .validation_utils import ValidationError, ValidationMethodCollector
 
 
 class Scene(Module):

--- a/src/scarlet2/source.py
+++ b/src/scarlet2/source.py
@@ -104,7 +104,7 @@ class Source(Component):
     component_ops: list
     """List of operators to combine `components` for the final model"""
 
-    def __init__(self, center, spectrum, morphology):
+    def __init__(self, center, spectrum, morphology, check_source=False):
         """
         Parameters
         ----------
@@ -115,10 +115,12 @@ class Source(Component):
             The spectrum of the source.
         morphology: array, :py:class:`~scarlet2.Morphology`
             The morphology of the source.
+        check_source: bool, optional
+            Whether to run validation checks on the source object. Default is False.
 
         Examples
         --------
-        A source  declaration is restricted to a context of a :py:class:`~scarlet2.Scene`,
+        A source declaration is restricted to a context of a :py:class:`~scarlet2.Scene`,
         which defines the :py:class:`~scarlet2.Frame` of the entire model.
 
         >>> with Scene(model_frame) as scene:
@@ -145,6 +147,17 @@ class Source(Component):
             print("Source can only be created within the context of a Scene")
             print("Use 'with Scene(frame) as scene: Source(...)'")
             raise
+
+        if check_source:
+            from .validation import check_source
+
+            validation_errors = check_source(self)
+            if validation_errors:
+                #! We can raise this as a ValueError or assign it to self.validation_errors
+                raise ValueError(
+                    "Source validation failed with the following errors:\n"
+                    + "\n".join(str(error) for error in validation_errors)
+                )
 
     def add_component(self, component, op):
         """Add `component` to this source

--- a/src/scarlet2/source.py
+++ b/src/scarlet2/source.py
@@ -1,4 +1,5 @@
 import operator
+from typing import Optional
 
 import equinox as eqx
 import jax
@@ -10,6 +11,7 @@ from .bbox import Box, overlap_slices
 from .module import Module
 from .morphology import Morphology
 from .spectrum import Spectrum
+from .validation import ValidationError, ValidationMethodCollector
 
 
 class Component(Module):
@@ -250,3 +252,24 @@ class PointSource(Source):
         morphology = frame.psf.morphology
 
         super().__init__(center, spectrum, morphology)
+
+
+class SourceValidator(metaclass=ValidationMethodCollector):
+    """A class containing all of the validation checks for Source objects.
+
+    Note that the metaclass is defined as `MethodCollector`, which collects all
+    validation methods in this class into a single class attribute list called
+    `validation_checks`. This allows for easy iteration over all checks."""
+
+    def __init__(self, source: Source):
+        self.source = source
+
+    def check_source_example(self) -> Optional[ValidationError]:
+        """Check that the source is valid.
+
+        Returns
+        -------
+        ValidationError or None
+            Returns a ValidationError if the check fails, otherwise None.
+        """
+        return None

--- a/src/scarlet2/source.py
+++ b/src/scarlet2/source.py
@@ -11,7 +11,7 @@ from .bbox import Box, overlap_slices
 from .module import Module
 from .morphology import Morphology
 from .spectrum import Spectrum
-from .validation import ValidationError, ValidationMethodCollector
+from .validation_utils import ValidationError, ValidationMethodCollector
 
 
 class Component(Module):
@@ -155,7 +155,6 @@ class Source(Component):
 
             validation_errors = check_source(self)
             if validation_errors:
-                #! We can raise this as a ValueError or assign it to self.validation_errors
                 raise ValueError(
                     "Source validation failed with the following errors:\n"
                     + "\n".join(str(error) for error in validation_errors)

--- a/src/scarlet2/validation.py
+++ b/src/scarlet2/validation.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
 from typing import Any, Optional
 
-import jax.numpy as jnp
-
-from scarlet2.observation import Observation
-from scarlet2.scene import Scene
-from scarlet2.source import Source
+from .observation import ObservationValidator
+from .scene import FitValidator
+from .source import SourceValidator
 
 
 @dataclass
@@ -25,7 +23,63 @@ class ValidationError:
         return base
 
 
-def check_observation(observation: Observation) -> list[ValidationError]:
+class ValidationMethodCollector(type):
+    """Metaclass that collects all validation methods in a class into a single"""
+
+    def __new__(cls, name, bases, namespace):
+        """Creates a list of callable methods when a new instances of a class is
+        created."""
+        cls = super().__new__(cls, name, bases, namespace)
+        cls.validation_checks = [
+            attr for attr, value in namespace.items() if callable(value) and not attr.startswith("__")
+        ]
+        return cls
+
+
+def _check(object, validation_class) -> list[ValidationError]:
+    """Check the object against the validation rules defined in the validation_class.
+
+    Parameters
+    ----------
+    object : Any
+        The object to check.
+    validation_class : type
+        The class containing the validation checks.
+
+    Returns
+    -------
+    list[ValidationError]
+        A list of validation errors found in the object.
+        If no errors are found, the list is empty.
+    """
+    validator = validation_class(object)
+    validation_errors = []
+    for check in validator.validation_checks:
+        if error := getattr(validator, check)():
+            validation_errors.append(error)
+
+    return validation_errors
+
+
+def check_fit(scene) -> list[ValidationError]:
+    """Check the scene after fitting against the various validation rules.
+
+    Parameters
+    ----------
+    scene : Scene
+        The scene object to check.
+
+    Returns
+    -------
+    list[ValidationError]
+        A list of validation errors found in the fit of the scene.
+        If no errors are found, the list is empty.
+    """
+
+    return _check(scene, FitValidator)
+
+
+def check_observation(observation) -> list[ValidationError]:
     """Check the observation object for consistency
 
     Parameters
@@ -40,17 +94,10 @@ def check_observation(observation: Observation) -> list[ValidationError]:
         If no errors are found, the list is empty.
     """
 
-    validation_errors = []
-
-    observation_checks = ObservationCheck.get_checks()
-    for check in observation_checks:
-        if error := check(observation).check():
-            validation_errors.append(error)
-
-    return validation_errors
+    return _check(observation, ObservationValidator)
 
 
-def check_scene(scene: Scene) -> list[ValidationError]:
+def check_scene(scene) -> list[ValidationError]:
     """Check the scene against the various validation rules.
 
     Parameters
@@ -72,7 +119,7 @@ def check_scene(scene: Scene) -> list[ValidationError]:
     return validation_errors
 
 
-def check_source(source: Source) -> list[ValidationError]:
+def check_source(source) -> list[ValidationError]:
     """Check the source against the various validation rules.
 
     Parameters
@@ -87,131 +134,4 @@ def check_source(source: Source) -> list[ValidationError]:
         If no errors are found, the list is empty.
     """
 
-    validation_errors = []
-
-    # Perform various checks on the source object
-    source_checks = SourceCheck.get_checks()
-    for check in source_checks:
-        if error := check(source).check():
-            validation_errors.append(error)
-
-    return validation_errors
-
-
-def check_fit(scene: Scene) -> list[ValidationError]:
-    """Check the scene after fitting against the various validation rules.
-
-    Parameters
-    ----------
-    scene : Scene
-        The scene object to check.
-
-    Returns
-    -------
-    list[ValidationError]
-        A list of validation errors found in the fit of the scene.
-        If no errors are found, the list is empty.
-    """
-
-    validation_errors = []
-    fit_checks = FitCheck.get_checks()
-    for check in fit_checks:
-        validation_errors.append(check(scene).check())
-
-    return validation_errors
-
-
-class BaseCheck:
-    """A base class for checks."""
-
-    def __init__(self):
-        pass
-
-    @classmethod
-    def get_checks(cls):
-        """Get the list of all registered checks."""
-        if not hasattr(cls, "_checks"):
-            cls._checks = []
-        return cls._checks
-
-    def check(self) -> Optional[ValidationError]:
-        """Run the check on the object."""
-        raise NotImplementedError("Subclasses should implement this method.")
-
-
-class ObservationCheck(BaseCheck):
-    """A base class for observation checks."""
-
-    def __init__(self, observation: Observation):
-        super().__init__()
-        self.observation = observation
-
-    def __init_subclass__(cls):
-        """Add all subclasses of ObservationCheck to the list of checks."""
-        ObservationCheck.get_checks().append(cls)
-
-
-class SourceCheck(BaseCheck):
-    """A base class for source checks."""
-
-    def __init__(self, source: Source):
-        super().__init__()
-        self.source = source
-
-    def __init_subclass__(cls):
-        """Add all subclasses of SourceCheck to the list of checks."""
-        SourceCheck.get_checks().append(cls)
-
-
-class FitCheck(BaseCheck):
-    """A base class for fit checks."""
-
-    def __init__(self, scene: Scene):
-        super().__init__()
-        self.scene = scene
-
-    def __init_subclass__(cls):
-        """Add all subclasses of FitCheck to the list of checks."""
-        FitCheck.get_checks().append(cls)
-
-
-class CheckWeightsNonNegative(ObservationCheck):
-    """Check that the weights in the observation are non-negative."""
-
-    def check(self) -> Optional[ValidationError]:
-        """Implementation of the check logic.
-
-        Returns
-        -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
-        """
-        if (self.observation.weights < 0).any():
-            return ValidationError(
-                "Weights in the observation must be non-negative.",
-                check=self.__class__.__name__,
-                #! Placeholder for a meaningful context
-                context={"observation.weights": self.observation.weights},
-            )
-        return None
-
-
-class CheckWeightIsFinite(ObservationCheck):
-    """Check that the weights in the observation are finite."""
-
-    def check(self) -> Optional[ValidationError]:
-        """Implementation of the check logic.
-
-        Returns
-        -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
-        """
-        if jnp.isinf(self.observation.weights).any():
-            return ValidationError(
-                "Weights in the observation must be finite.",
-                check=self.__class__.__name__,
-                #! Placeholder for a meaningful context
-                context={"observation.weights": self.observation.weights},
-            )
-        return None
+    return _check(source, SourceValidator)

--- a/src/scarlet2/validation.py
+++ b/src/scarlet2/validation.py
@@ -1,39 +1,7 @@
-from dataclasses import dataclass
-from typing import Any, Optional
-
 from .observation import ObservationValidator
 from .scene import FitValidator
 from .source import SourceValidator
-
-
-@dataclass
-class ValidationError:
-    """Represents a validation error. Primarily used to convey the context of the
-    error to the user and give an indication of what check failed.
-    """
-
-    message: str
-    check: str
-    context: Optional[Any] = None
-
-    def __str__(self):
-        base = f"{self.message} | Check={self.check}"
-        if self.context is not None:
-            base += f" | Context={self.context})"
-        return base
-
-
-class ValidationMethodCollector(type):
-    """Metaclass that collects all validation methods in a class into a single"""
-
-    def __new__(cls, name, bases, namespace):
-        """Creates a list of callable methods when a new instances of a class is
-        created."""
-        cls = super().__new__(cls, name, bases, namespace)
-        cls.validation_checks = [
-            attr for attr, value in namespace.items() if callable(value) and not attr.startswith("__")
-        ]
-        return cls
+from .validation_utils import ValidationError
 
 
 def _check(object, validation_class) -> list[ValidationError]:

--- a/src/scarlet2/validation.py
+++ b/src/scarlet2/validation.py
@@ -1,46 +1,217 @@
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import jax.numpy as jnp
 
 from scarlet2.observation import Observation
 from scarlet2.scene import Scene
+from scarlet2.source import Source
 
 
-def check_observation(observation: Optional[Observation] = None):
+@dataclass
+class ValidationError:
+    """Represents a validation error. Primarily used to convey the context of the
+    error to the user and give an indication of what check failed.
+    """
+
+    message: str
+    check: str
+    context: Optional[Any] = None
+
+    def __str__(self):
+        base = f"{self.message} | Check={self.check}"
+        if self.context is not None:
+            base += f" | Context={self.context})"
+        return base
+
+
+def check_observation(observation: Observation) -> list[ValidationError]:
     """Check the observation object for consistency
 
     Parameters
     ----------
-    observation: Observation, optional
-        The observation object to check. If None, no checks are performed. Default is None
+    observation: Observation
+        The observation object to check.
+
+    Returns
+    -------
+    list[ValidationError]
+        A list of validation errors found in the observation object.
+        If no errors are found, the list is empty.
     """
-    if observation is None:
-        return
 
-    pass
+    validation_errors = []
+
+    observation_checks = ObservationCheck.get_checks()
+    for check in observation_checks:
+        if error := check(observation).check():
+            validation_errors.append(error)
+
+    return validation_errors
 
 
-def check_scene(scene: Optional[Scene] = None):
+def check_scene(scene: Scene) -> list[ValidationError]:
     """Check the scene against the various validation rules.
 
     Parameters
     ----------
-    scene : Scene, optional
-        The scene object to check, by default None
+    scene : Scene
+        The scene object to check.
+
+    Returns
+    -------
+    list[ValidationError]
+        A list of validation errors found in the source objects in the scene.
+        If no errors are found, the list is empty.
     """
-    if scene is None:
-        return
 
-    pass
+    validation_errors = []
+    for source in scene.sources:
+        validation_errors.extend(check_source(source))
+
+    return validation_errors
 
 
-def check_fit(scene: Optional[Scene] = None):
+def check_source(source: Source) -> list[ValidationError]:
+    """Check the source against the various validation rules.
+
+    Parameters
+    ----------
+    source : Source
+        The source object to check.
+
+    Returns
+    -------
+    list[ValidationError]
+        A list of validation errors found in the source object.
+        If no errors are found, the list is empty.
+    """
+
+    validation_errors = []
+
+    # Perform various checks on the source object
+    source_checks = SourceCheck.get_checks()
+    for check in source_checks:
+        if error := check(source).check():
+            validation_errors.append(error)
+
+    return validation_errors
+
+
+def check_fit(scene: Scene) -> list[ValidationError]:
     """Check the scene after fitting against the various validation rules.
 
     Parameters
     ----------
-    scene : Scene, optional
-        The scene object to check, by default None
-    """
-    if scene is None:
-        return
+    scene : Scene
+        The scene object to check.
 
-    pass
+    Returns
+    -------
+    list[ValidationError]
+        A list of validation errors found in the fit of the scene.
+        If no errors are found, the list is empty.
+    """
+
+    validation_errors = []
+    fit_checks = FitCheck.get_checks()
+    for check in fit_checks:
+        validation_errors.append(check(scene).check())
+
+    return validation_errors
+
+
+class BaseCheck:
+    """A base class for checks."""
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_checks(cls):
+        """Get the list of all registered checks."""
+        if not hasattr(cls, "_checks"):
+            cls._checks = []
+        return cls._checks
+
+    def check(self) -> Optional[ValidationError]:
+        """Run the check on the object."""
+        raise NotImplementedError("Subclasses should implement this method.")
+
+
+class ObservationCheck(BaseCheck):
+    """A base class for observation checks."""
+
+    def __init__(self, observation: Observation):
+        super().__init__()
+        self.observation = observation
+
+    def __init_subclass__(cls):
+        """Add all subclasses of ObservationCheck to the list of checks."""
+        ObservationCheck.get_checks().append(cls)
+
+
+class SourceCheck(BaseCheck):
+    """A base class for source checks."""
+
+    def __init__(self, source: Source):
+        super().__init__()
+        self.source = source
+
+    def __init_subclass__(cls):
+        """Add all subclasses of SourceCheck to the list of checks."""
+        SourceCheck.get_checks().append(cls)
+
+
+class FitCheck(BaseCheck):
+    """A base class for fit checks."""
+
+    def __init__(self, scene: Scene):
+        super().__init__()
+        self.scene = scene
+
+    def __init_subclass__(cls):
+        """Add all subclasses of FitCheck to the list of checks."""
+        FitCheck.get_checks().append(cls)
+
+
+class CheckWeightsNonNegative(ObservationCheck):
+    """Check that the weights in the observation are non-negative."""
+
+    def check(self) -> Optional[ValidationError]:
+        """Implementation of the check logic.
+
+        Returns
+        -------
+        ValidationError or None
+            Returns a ValidationError if the check fails, otherwise None.
+        """
+        if (self.observation.weights < 0).any():
+            return ValidationError(
+                "Weights in the observation must be non-negative.",
+                check=self.__class__.__name__,
+                #! Placeholder for a meaningful context
+                context={"observation.weights": self.observation.weights},
+            )
+        return None
+
+
+class CheckWeightIsFinite(ObservationCheck):
+    """Check that the weights in the observation are finite."""
+
+    def check(self) -> Optional[ValidationError]:
+        """Implementation of the check logic.
+
+        Returns
+        -------
+        ValidationError or None
+            Returns a ValidationError if the check fails, otherwise None.
+        """
+        if jnp.isinf(self.observation.weights).any():
+            return ValidationError(
+                "Weights in the observation must be finite.",
+                check=self.__class__.__name__,
+                #! Placeholder for a meaningful context
+                context={"observation.weights": self.observation.weights},
+            )
+        return None

--- a/src/scarlet2/validation.py
+++ b/src/scarlet2/validation.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from scarlet2.observation import Observation
+from scarlet2.scene import Scene
+
+
+def check_observation(observation: Optional[Observation] = None):
+    """Check the observation object for consistency
+
+    Parameters
+    ----------
+    observation: Observation, optional
+        The observation object to check. If None, no checks are performed. Default is None
+    """
+    if observation is None:
+        return
+
+    pass
+
+
+def check_scene(scene: Optional[Scene] = None):
+    """Check the scene against the various validation rules.
+
+    Parameters
+    ----------
+    scene : Scene, optional
+        The scene object to check, by default None
+    """
+    if scene is None:
+        return
+
+    pass
+
+
+def check_fit(scene: Optional[Scene] = None):
+    """Check the scene after fitting against the various validation rules.
+
+    Parameters
+    ----------
+    scene : Scene, optional
+        The scene object to check, by default None
+    """
+    if scene is None:
+        return
+
+    pass

--- a/src/scarlet2/validation_utils.py
+++ b/src/scarlet2/validation_utils.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class ValidationError:
+    """Represents a validation error. Primarily used to convey the context of the
+    error to the user and give an indication of what check failed.
+    """
+
+    message: str
+    check: str
+    context: Optional[Any] = None
+
+    def __str__(self):
+        base = f"{self.message} | Check={self.check}"
+        if self.context is not None:
+            base += f" | Context={self.context})"
+        return base
+
+
+class ValidationMethodCollector(type):
+    """Metaclass that collects all validation methods in a class into a single"""
+
+    def __new__(cls, name, bases, namespace):
+        """Creates a list of callable methods when a new instances of a class is
+        created."""
+        cls = super().__new__(cls, name, bases, namespace)
+        cls.validation_checks = [
+            attr for attr, value in namespace.items() if callable(value) and not attr.startswith("__")
+        ]
+        return cls


### PR DESCRIPTION
## WIP - Scaffolding for validation

Implementing some early scaffolding code for validation with the assumption that we want validation in three places:

### 1) During input
I believe this means just after instantiating a `Observation` object. The scaffolding would support two modes:
```
obs = Observation(data, weights, ..., check_observation=True)  # check_observation is False by default
``` 
or
```
from scarlet2.validation import check_observation

obs = Observation(data, weights, ...)
check_observation(obs)
```

### 2) After initialization of sources
The scaffolding would again support two modes: 
```
Source(center, spectrum, morph, check_source=True)
```
or
```
from scarlet2.validation import check_source

source = Source(center, spectrum, morph)
check_scene(source)
```

### 3) Output failures
I believe this means examining what has happened after `scene.fit()`. Again two modes would be supported:
```
scene.fit(obs, parameters, ..., check_fit=True)  # check_fit is False by default
```
or
```
from scarlet2.validation import check_fit

scene_ = scene.fit(obs, parameters, ...)
check_fit(scene_)
```


TODO:

- [x] Determine at which level to place the `check_source` function in source.py. `Source` is a child class of `Component` and there are a few other class in that module as well. I _think_ it makes sense to but the `check_source` function in the parent class, `Component`, and if so, it probably makes sense to rename it to `check_component`. 
