### PR TITLE
Global automated validation switch

### DIFF
--- a/src/scarlet2/__init__.py
+++ b/src/scarlet2/__init__.py
@@ -31,6 +31,7 @@ from .scene import Scene
 from .source import Component, DustComponent, PointSource, Source
 from .spectrum import Spectrum, StaticArraySpectrum, TransientArraySpectrum
 from .validation import check_fit, check_observation, check_scene, check_source
+from .validation_utils import VALIDATION_SWITCH, set_validation
 from .wavelets import Starlet
 
 # for * imports and docs
@@ -67,4 +68,6 @@ __all__ = [
     "check_observation",
     "check_scene",
     "check_source",
+    "VALIDATION_SWITCH",
+    "set_validation",
 ]

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -166,7 +166,7 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
         ValidationError or None
             Returns a ValidationError if the check fails, otherwise None.
         """
-        if (self.observation.weights < 0).any():
+        if self.observation.weights is not None and (self.observation.weights < 0).any():
             return ValidationError(
                 "Weights in the observation must be non-negative.",
                 check=self.__class__.__name__,
@@ -183,7 +183,7 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
         ValidationError or None
             Returns a ValidationError if the check fails, otherwise None.
         """
-        if jnp.isinf(self.observation.weights).any():
+        if self.observation.weights is not None and jnp.isinf(self.observation.weights).any():
             return ValidationError(
                 "Weights in the observation must be finite.",
                 check=self.__class__.__name__,

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -29,9 +29,7 @@ class Observation(Module):
     renderer: (Renderer, eqx.nn.Sequential) = eqx.field(static=True)
     """Renderer to translate from the model frame the observation frame"""
 
-    def __init__(
-        self, data, weights, psf=None, wcs=None, channels=None, renderer=None, check_observation=False
-    ):
+    def __init__(self, data, weights, psf=None, wcs=None, channels=None, renderer=None):
         self.data = data
         self.weights = weights
         if channels is None:
@@ -41,7 +39,10 @@ class Observation(Module):
             renderer = NoRenderer()
         self.renderer = renderer
 
-        if check_observation:
+        # (re)-import `VALIDATION_SWITCH` at runtime to avoid using a static/old value
+        from .validation_utils import VALIDATION_SWITCH
+
+        if VALIDATION_SWITCH:
             from .validation import check_observation
 
             validation_errors = check_observation(self)

--- a/src/scarlet2/scene.py
+++ b/src/scarlet2/scene.py
@@ -219,7 +219,6 @@ class Scene(Module):
         e_rel=1e-4,
         progress_bar=True,
         callback=None,
-        check_fit=False,
         **kwargs,
     ):
         """Fit model `parameters` of every source in the scene to match `observations`.
@@ -247,9 +246,6 @@ class Scene(Module):
             Signature `callback(scene, convergence, loss) -> None`, where
             `convergence` is a tree of the same structure as `scene`, and `loss`
             is the current value of the log_posterior.
-        check_fit: bool, optional
-            Whether to run validation checks on the scene after fitting.
-            Default is `False`.
         **kwargs: dict, optional
             Additional keyword arguments passed to the `optax.scale_by_adam` optimizer.
 
@@ -338,7 +334,10 @@ class Scene(Module):
 
         returned_scene = _constraint_replace(scene, parameters)  # transform back to constrained variables
 
-        if check_fit:
+        # (re)-import `VALIDATION_SWITCH` at runtime to avoid using a static/old value
+        from .validation_utils import VALIDATION_SWITCH
+
+        if VALIDATION_SWITCH:
             from .validation import check_fit
 
             validation_errors = check_fit(returned_scene)

--- a/src/scarlet2/source.py
+++ b/src/scarlet2/source.py
@@ -106,7 +106,7 @@ class Source(Component):
     component_ops: list
     """List of operators to combine `components` for the final model"""
 
-    def __init__(self, center, spectrum, morphology, check_source=False):
+    def __init__(self, center, spectrum, morphology):
         """
         Parameters
         ----------
@@ -117,8 +117,6 @@ class Source(Component):
             The spectrum of the source.
         morphology: array, :py:class:`~scarlet2.Morphology`
             The morphology of the source.
-        check_source: bool, optional
-            Whether to run validation checks on the source object. Default is False.
 
         Examples
         --------
@@ -150,7 +148,10 @@ class Source(Component):
             print("Use 'with Scene(frame) as scene: Source(...)'")
             raise
 
-        if check_source:
+        # (re)-import `VALIDATION_SWITCH` at runtime to avoid using a static/old value
+        from .validation_utils import VALIDATION_SWITCH
+
+        if VALIDATION_SWITCH:
             from .validation import check_source
 
             validation_errors = check_source(self)

--- a/src/scarlet2/validation_utils.py
+++ b/src/scarlet2/validation_utils.py
@@ -1,5 +1,26 @@
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# A global switch that toggles automated validation checks.
+VALIDATION_SWITCH = True
+
+
+def set_validation(state: bool = True):
+    """Set the global validation switch.
+
+    Parameters
+    ----------
+    state : bool, optional
+        If True, validation checks will be automatically performed. If False,
+        they will be skipped. Defaults to True.
+    """
+
+    global VALIDATION_SWITCH
+    VALIDATION_SWITCH = state
+    logger.info(f"Automated validation checks are now {'enabled' if VALIDATION_SWITCH else 'disabled'}.")
 
 
 @dataclass


### PR DESCRIPTION
Introducing a `VALIDATION_SWITCH` variable to enable/disable automated validation checks.

The `VALIDATION_SWITCH` is a global variable (defaults to True) that can be set using the `set_validation(bool)` function. This PR also removes the `check_*` values that were optional when defining `Observation` or `Source` objects, or calling `.fit()`. 

In practice, if the user wanted to turn off automatic validation it would look like this:
```
from scarlet2 import *

# turn off automatic validation
set_validation(False)

# create Observation instance (with data that would fail validation for instance)
obs = Observation(data, weights, psf=ArrayPSF(psf), channels=channels)

# manually check for errors
errors = check_observation(obs)
# prints out the errors

# turn the automatic validation again
set_validation(True)

# create Observation instance (with data that would fail validation for instance)
obs = Observation(data, weights, psf=ArrayPSF(psf), channels=channels)
# prints out the errors
```

If the user wanted to keep the automatic validation it would look like this:
```
from scarlet2 import *

# create Observation instance (with data that would fail validation for instance)
obs = Observation(data, weights, psf=ArrayPSF(psf), channels=channels)
# prints out the errors