### PR TITLE
Fix variable type bug in Observation

### DIFF
--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -35,7 +35,7 @@ class Observation(Module):
         self.data = data
         self.weights = weights
         if channels is None:
-            channels = range(data.shape[0])
+            channels = list(range(data.shape[0]))
         self.frame = Frame(Box(data.shape), psf, wcs, channels)
         if renderer is None:
             renderer = NoRenderer()


### PR DESCRIPTION
I'm fairly sure this is a bug - if a `channels` list is not provided when instantiating an Observation object, a default will be created, but here we are just creating a `range(...)`. 

In the frame.py module, something similar is happening, but there is the default is `channels = list(range(data.shape[0]))`. 

Additionally creating an Observation instance will raise an error on this line because of `range`.