### PR TITLE
Pinning JAX to 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "equinox",
-    "jax",
+    "jax==0.6.2",
     "astropy",
     "numpy",
     "matplotlib",


### PR DESCRIPTION
The latest JAX release (0.7.0) has a bug that is causing build and tests failures. Pinning JAX to the last stable release (0.6.2) addresses the problem for now.