### PR TITLE
Housekeeping

### DIFF
--- a/docs/howto/multiresolution.ipynb
+++ b/docs/howto/multiresolution.ipynb
@@ -22,11 +22,10 @@
     "\n",
     "# Import Packages\n",
     "import jax.numpy as jnp\n",
+    "import scarlet2\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.table import Table\n",
-    "from astropy.wcs import WCS\n",
-    "\n",
-    "import scarlet2"
+    "from astropy.wcs import WCS"
    ]
   },
   {

--- a/src/scarlet2/module.py
+++ b/src/scarlet2/module.py
@@ -324,8 +324,8 @@ class Parameters:
                     if isinstance(attrib, SkyCoord):
                         setattr(field, name, frame.get_pixel(attrib))
                         used_sky_coords_prior = fieldname == "prior"
-                except Exception as e:
-                    print(f"Error processing fieldname '{fieldname}'. - {e}")
+                except Exception:
+                    # jax throws exceptions for deprecated attributes, so we ignore exceptions silently
                     pass
 
             if used_sky_coords_prior:

--- a/src/scarlet2/morphology.py
+++ b/src/scarlet2/morphology.py
@@ -28,7 +28,7 @@ class ProfileMorphology(Morphology):
     """
     ellipticity: (None, jnp.array)
     """Ellipticity of the profile"""
-    _shape: tuple = eqx.field(init=False, repr=False)
+    _shape: tuple = eqx.field(repr=False)
 
     def __init__(self, size, ellipticity=None, shape=None):
         if isinstance(size, u.Quantity):

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -27,7 +27,7 @@ class Observation(Module):
     """Statistical weights (usually inverse variance) for :py:meth:`log_likelihood`"""
     frame: Frame
     """Metadata to describe what view of the sky `data` amounts to"""
-    renderer: (Renderer, eqx.nn.Sequential) = eqx.field(static=True)
+    renderer: (Renderer, eqx.nn.Sequential)
     """Renderer to translate from the model frame the observation frame"""
 
     def __init__(self, data, weights, psf=None, wcs=None, channels=None, renderer=None):

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -11,9 +11,9 @@ from .renderer import (
     AdjustToFrame,
     ChannelRenderer,
     ConvolutionRenderer,
-    MultiresolutionRenderer,
     NoRenderer,
     Renderer,
+    ResamplingRenderer,
 )
 from .validation_utils import ValidationError, ValidationMethodCollector
 
@@ -152,7 +152,7 @@ class Observation(Module):
                     # 3)b) Resample at the obs resolution
                     # 3)c) deconvolve with model PSF and re-convolve with obs PSF
                     # 4) Wrap the Fourier image and crop to obs frame
-                    renderers.append(MultiresolutionRenderer(frame, self.frame))
+                    renderers.append(ResamplingRenderer(frame, self.frame))
 
                 else:
                     renderers.append(ConvolutionRenderer(frame, self.frame))

--- a/src/scarlet2/scene.py
+++ b/src/scarlet2/scene.py
@@ -430,6 +430,8 @@ class Scene(Module):
 
             # update the parameters with the best-fit spectrum solution
             channel_map = ChannelRenderer(self.frame, obs.frame).channel_map
+            if channel_map is not None:
+                channel_map.get_slice()
             noise_bg = 1 / jnp.median(jnp.sqrt(obs.weights), axis=(-2, -1))
             for i in spectrum_parameters:
                 src_ = self.sources[i]

--- a/src/scarlet2/source.py
+++ b/src/scarlet2/source.py
@@ -1,7 +1,6 @@
 import operator
 from typing import Optional
 
-import equinox as eqx
 import jax
 import jax.numpy as jnp
 from astropy.coordinates import SkyCoord
@@ -29,7 +28,7 @@ class Component(Module):
     """Spectrum model"""
     morphology: (jnp.array, Morphology)
     """Morphology model"""
-    bbox: Box = eqx.field(init=False)
+    bbox: Box
     """Bounding box of the model, in pixel coordinates of the model frame"""
 
     def __init__(self, center, spectrum, morphology):


### PR DESCRIPTION
This PR fixes three different problems.

1. It removed any occurence of equinox dataclass attributes that were defined with `eqx.field(init=False)`. That used to be the mechanism to define an attribute that is not present as argument in the default `__init__`. However, equinox new complains about this problem rather verbosely, and we always have custom inits for those ones anyway, so uses of `init=False` and subsequence `getattr` have been replaced by standard `self.attribute = attribute`.
2. I managed to remove the last occurrence of `eqx.field(static=True)` from the code base. It was for `Observation.renderer` and was used to paper over a different problem. Some of the renderers use slices to narrow the number of channels or the spatial box, but these cannot be hashed in python <3.12. JIT will not worked if static parameters cannot be hashed, so I cerated a hashable slice data class.
3. jax throws a lot of exceptions when a class attribute is requested that is deprecated. Since we seek to convert astropy units to pixel units in our parameters, we need to inspect every attribute. That causes a lot of spam (#184). I silence these.