### PR TITLE
create the `lsst_utils` modules

### DIFF
--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -207,10 +207,10 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
         detector = int(detector)
         dataId_calexp = {"visit": visit, "detector": detector}
 
-        img = make_image_cutout(
-            service, ra, dec, cutout_size=cutout_size * 50.0, imtype="calexp", dataId=dataId_calexp
-        )
         if i == 0:
+            img = make_image_cutout(
+                service, ra, dec, cutout_size=cutout_size, imtype="calexp", dataId=dataId_calexp
+            )
             img_ref = img
             # no warping is needed for the reference
             img_warped = img_ref
@@ -218,6 +218,9 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
             shifted_wcs = img_ref.getWcs().copyAtShiftedPixelOrigin(offset)
             wcs_ref = WCS(shifted_wcs.getFitsMetadata())
         else:
+            img = make_image_cutout(
+                service, ra, dec, cutout_size=cutout_size * 50.0, imtype="calexp", dataId=dataId_calexp
+            )
             img_warped = warp_img(img_ref, img, img_ref.getWcs(), img.getWcs())
         im_arr = img_warped.image.array
         var_arr = img_warped.variance.array

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -190,6 +190,8 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service):
 
     observations = []
     channels_sc2 = []
+    img_ref = None
+    wcs_ref = None
     for i, src in enumerate(dia_src):
         ccdvisitID = src["ccdVisitId"]
         band = str(src["filterName"])
@@ -198,8 +200,6 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service):
         visit = int(visit)
         detector = int(detector)
         dataId_calexp = {"visit": visit, "detector": detector}
-        img_ref = None
-        wcs_ref = None
 
         img = make_image_cutout(
             service, ra, dec, cutout_size=cutout_size * 50.0, imtype="calexp", dataId=dataId_calexp

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -1,0 +1,268 @@
+import time
+import numpy as np
+import uuid
+import os
+import glob
+import math
+import pandas
+import matplotlib.pyplot as plt
+import tempfile
+import getpass
+from PIL import Image
+from IPython.display import Image as dimg
+
+import lsst.geom as geom
+import lsst.resources
+import lsst.afw.display as afwDisplay
+from lsst.afw.image import Exposure, ExposureF
+from lsst.pipe.tasks.registerImage import RegisterConfig, RegisterTask
+from lsst.rsp import get_tap_service
+from lsst.rsp.utils import get_access_token
+from lsst.afw.fits import MemFileManager
+
+import pyvo
+from pyvo.dal.adhoc import DatalinkResults, SodaQuery
+
+import astropy
+from astropy import units as u
+from astropy.coordinates import SkyCoord, Angle
+from astropy.io import fits
+from astropy.wcs import WCS
+
+import scarlet2
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.optimize import curve_fit
+from scipy.stats import skew
+import getpass
+
+import lsst.daf.butler as dafButler
+import lsst.afw.display as afwDisplay
+from lsst.geom import Point2D, radToDeg, SpherePoint, degrees
+
+from astropy.wcs import WCS
+from astropy.io import fits
+import jax.numpy as jnp
+import lsst.afw.geom as afwGeom
+import lsst.afw.image as afwImage
+import lsst.afw.display as afwDisplay
+import lsst.afw.table as afwTable
+import lsst.geom as geom
+from lsst.afw.detection import Psf
+from lsst.meas.algorithms import WarpedPsf
+
+def warp_img(ref_img, img_to_warp, ref_wcs, wcs_to_warp):
+    """Warp and rotate an image onto the coordinate system of another image
+
+   Parameters
+    ----------
+    ref_img: 'ExposureF'
+        is the reference image for the re-projection
+    img_to_warp: 'ExposureF'
+        the image to rotate and warp onto the reference image's wcs
+    ref_wcs: 'wcs object'
+        the wcs of the reference image (i.e. ref_img.getWcs() )
+    wcs_to_warp: 'wcs object'
+        the wcs of the image to warp (i.e. img_to_warp.getWcs() )
+   Returns
+    -------
+    warpedExp: 'ExposureF'
+        a reprojected, rotated image that is aligned and matched to ref_image
+     """
+    config = RegisterConfig()
+    task = RegisterTask(name="register", config=config)
+    warpedExp = task.warpExposure(img_to_warp, wcs_to_warp, ref_wcs,
+                                  ref_img.getBBox())
+
+    return warpedExp
+
+def read_cutout_mem(sq):
+    """Read the cutout into memory
+
+    Parameters
+    ----------
+    sq : 'dict'
+        returned from SodaQuery.from_resource()
+
+    Returns
+    -------
+    exposure : 'ExposureF'
+        the cutout in exposureF format
+    """
+
+    cutout_bytes = sq.execute_stream().read()
+    sq.raise_if_error()
+    mem = MemFileManager(len(cutout_bytes))
+    mem.setData(cutout_bytes, len(cutout_bytes))
+    exposure = ExposureF(mem)
+
+    return exposure
+
+def make_image_cutout(tap_service, ra, dec, dataId, cutout_size=0.01,
+                      imtype=None, filename=None):
+    """Wrapper function to generate a cutout using the cutout tool
+
+   Parameters
+    ----------
+    tap_service : an instance of the TAP service
+    ra, dec : 'float'
+        the ra and dec of the cutout center
+    dataId : 'dict'
+        the dataId of the image to make a cutout from. The format
+        must correspond to that provided for parameter 'imtype'
+    cutout_size : 'float', optional
+        edge length in degrees of the cutout
+    imtype : 'string', optional
+        string containing the type of LSST image to generate
+        a cutout of (e.g. deepCoadd, calexp). If imtype=None,
+        the function will assume a deepCoadd.
+    filename : 'string', optional
+        filename of the resulting cutout (which has fits format)
+
+   Returns
+    -------
+    exposure : 'ExposureF'
+        the cutout in exposureF format
+    """
+
+    spherePoint = geom.SpherePoint(ra*geom.degrees, dec*geom.degrees)
+
+    if imtype == 'calexp':
+
+        query = "SELECT access_format, access_url, dataproduct_subtype, " + \
+            "lsst_visit, lsst_detector, lsst_band " + \
+            "FROM dp02_dc2_catalogs.ObsCore WHERE dataproduct_type = 'image' " + \
+            "AND obs_collection = 'LSST.DP02' " + \
+            "AND dataproduct_subtype = 'lsst.calexp' " + \
+            "AND lsst_visit = " + str(dataId["visit"]) + " " + \
+            "AND lsst_detector = " + str(dataId["detector"])
+        results = tap_service.search(query)
+
+    else:
+        # Find the tract and patch that contain this point
+        tract = dataId["tract"]
+        patch = dataId["patch"]
+
+        # add optional default band if it is not contained in the dataId
+        band = dataId["band"]
+
+        query = "SELECT access_format, access_url, dataproduct_subtype, " + \
+            "lsst_patch, lsst_tract, lsst_band " + \
+            "FROM dp02_dc2_catalogs.ObsCore WHERE dataproduct_type = 'image' " + \
+            "AND obs_collection = 'LSST.DP02' " + \
+            "AND dataproduct_subtype = 'lsst.deepCoadd_calexp' " + \
+            "AND lsst_tract = " + str(tract) + " " + \
+            "AND lsst_patch = " + str(patch) + " " + \
+            "AND lsst_band = " + "'" + str(band) + "' "
+        results = tap_service.search(query)
+
+    # Get datalink
+    dataLinkUrl = results[0].getdataurl()
+    auth_session = tap_service._session
+    print(dataLinkUrl)
+    dl = DatalinkResults.from_result_url(dataLinkUrl,
+                                         session=auth_session)
+
+    # from_resource: creates a instance from
+    # a number of records and a Datalink Resource.
+    sq = SodaQuery.from_resource(dl,
+                                 dl.get_adhocservice_by_id("cutout-sync"),
+                                 session=auth_session)
+
+    sq.circle = (spherePoint.getRa().asDegrees() * u.deg,
+                 spherePoint.getDec().asDegrees() * u.deg,
+                 cutout_size * u.deg)
+
+    exposure = read_cutout_mem(sq)
+
+    # cutout_bytes = sq.execute_stream().read()
+    # mem = MemFileManager(len(cutout_bytes))
+    # mem.setData(cutout_bytes, len(cutout_bytes))
+    # exposure = ExposureF(mem)
+    
+    return exposure
+
+def dia_source_to_scene(cutout_size_pix, dia_src, service):
+    i = 0
+    cutout_size_pix = 131
+    cutout_size = cutout_size_pix * 0.2 / 3600.0
+    ra = dia_src['ra']
+    dec = dia_src['decl']
+
+    observations=[]
+    channels_sc2=[]
+    for i,src in enumerate(dia_src):
+        ccdvisitID = src['ccdVisitId']
+        band = str(src['filterName'])
+        visit = str(ccdvisitID)[:-3]
+        detector = str(ccdvisitID)[-3:]
+        visit = int(visit)
+        detector = int(detector)
+        dataId_calexp = {'visit': visit, 'detector': detector} 
+        
+        if i == 0:
+            img_ref = make_image_cutout(service, ra, dec, cutout_size=cutout_size,
+                                        imtype='calexp', dataId=dataId_calexp)      
+            im_arr = img_ref.image.array                                   
+            var_arr = img_ref.variance.array                                    
+            N1,N2 = im_arr.shape
+            image_sc2 = im_arr.reshape(1, N1,N2)
+            N1,N2 = var_arr.shape
+            weight_sc2 = 1/var_arr.reshape(1, N1,N2)
+            info_calexp = img_ref.getInfo()
+            psf_calexp = info_calexp.getPsf()
+            point_tuple = (int(img_ref.image.array.shape[0]/2),int(img_ref.image.array.shape[1]/2))
+            point_image = Point2D(point_tuple)
+            psf_ref = psf_calexp.computeImage(point_image).convertF()
+            N1,N2 = psf_ref.array.shape
+            psf_sc2 = psf_ref.array.reshape(1, N1,N2)
+            # maybe we can we have an option to cache the coutouts
+            # filename = os.path.join(tempdir,'cutout_' + str(i) + '.fits')
+            img_ref.writeFits(filename)
+            f=fits.open(filename)
+            wcs_ref = WCS(f[1].header)
+
+            obs = scarlet2.Observation(jnp.array(image_sc2).astype(float),
+                            weights=jnp.array(weight_sc2).astype(float),
+                            psf=scarlet2.ArrayPSF(jnp.array(psf_sc2).astype(float)),
+                            wcs=wcs_ref,
+                            channels=[(band,str(i))])
+            channels_sc2.append((band,str(i)))
+            observations.append(obs)
+        else:
+            img = make_image_cutout(service, ra, dec, cutout_size=cutout_size*50.0,
+                                    imtype='calexp', dataId=dataId_calexp)
+            img_warped = warp_img(img_ref, img, img_ref.getWcs(), img.getWcs())
+            fig, ax = plt.subplots(1, 1, figsize=(2, 2))
+            im_arr = img_warped.image.array
+            var_arr = img_warped.variance.array
+            N1,N2 = im_arr.shape
+            image_sc2 = im_arr.reshape(1, N1,N2)
+            N1,N2 = var_arr.shape
+            weight_sc2 = 1/var_arr.reshape(1, N1,N2)
+            info_calexp = img.getInfo()
+            psf_calexp = info_calexp.getPsf()
+            point_tuple = (int(img_warped.image.array.shape[0]/2),int(img_warped.image.array.shape[1]/2))
+            point_image = Point2D(point_tuple)
+            psf = psf_calexp.computeImage(point_image).convertF()
+            xyTransform = afwGeom.makeWcsPairTransform(img.wcs,img_warped.wcs)
+            psf_w = WarpedPsf(img.getPsf(), xyTransform)
+            point_tuple = (int(img_warped.image.array.shape[0]/2),int(img_warped.image.array.shape[1]/2))
+            point_image = Point2D(point_tuple)
+            psf_warped = psf_w.computeImage(point_image).convertF()
+            if np.sum(psf_warped.array)==0:
+                print('PSF model unavailable, skipping')
+                continue
+            N1,N2 = psf_warped.array.shape
+            psf_sc2 = psf_warped.array.reshape(1, N1,N2)
+            # filename = os.path.join(tempdir, 'cutout_' + str(i) + '.fits')
+            # img_ref.writeFits(filename)
+            # f=fits.open(filename)
+            wcs = WCS(f[1].header)
+            obs = scarlet2.Observation(jnp.array(image_sc2).astype(float),
+                            weights=jnp.array(weight_sc2).astype(float),
+                            psf=scarlet2.ArrayPSF(jnp.array(psf_sc2).astype(float)),
+                            wcs=wcs,
+                            channels=[(band,str(i))])
+            channels_sc2.append((band,str(i)))
+            observations.append(obs)

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -195,9 +195,6 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
     vmin = -200
     vmax = 300
 
-    if plot_images:
-        fig, ax = plt.subplots(1, 1, figsize=(2, 2))
-
     for i, src in enumerate(dia_src):
         ccdvisitID = src["ccdVisitId"]
         band = str(src["filterName"])
@@ -253,6 +250,7 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
         observations.append(obs)
 
         if plot_images:
+            _, ax = plt.subplots(1, 1, figsize=(2, 2))
             plt.imshow(im_arr, origin="lower", cmap="gray", vmin=vmin, vmax=vmax)
             ax.set_xticklabels([])
             ax.set_yticklabels([])
@@ -267,5 +265,4 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
             )
             plt.show()
             plt.close()
-
     return observations, channels_sc2

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -1,6 +1,7 @@
 import jax.numpy as jnp
 import lsst.afw.geom as afwGeom
 import lsst.geom as geom
+import matplotlib.pyplot as plt
 import numpy as np
 from astropy import units as u
 from astropy.wcs import WCS
@@ -10,7 +11,6 @@ from lsst.geom import Point2D
 from lsst.meas.algorithms import WarpedPsf
 from lsst.pipe.tasks.registerImage import RegisterConfig, RegisterTask
 from pyvo.dal.adhoc import DatalinkResults, SodaQuery
-import matplotlib.pyplot as plt
 
 import scarlet2
 
@@ -251,15 +251,18 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
         observations.append(obs)
 
         if plot_images:
-            plt.imshow(im_arr, origin='lower', cmap='gray', vmin=vmin, vmax=vmax)
+            plt.imshow(im_arr, origin="lower", cmap="gray", vmin=vmin, vmax=vmax)
             ax.set_xticklabels([])
             ax.set_yticklabels([])
             ax.set_xticks([])
             ax.set_yticks([])
             ax.text(
-                .1, .9, r'$\Delta$t='
-                    + str(round(src['midPointTai']-first_time, 2)),
-                    color='white', fontsize=12)
+                0.1,
+                0.9,
+                r"$\Delta$t=" + str(round(src["midPointTai"] - first_time, 2)),
+                color="white",
+                fontsize=12,
+            )
             plt.show()
             plt.close()
 

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -218,8 +218,7 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
             shifted_wcs = img_ref.getWcs().copyAtShiftedPixelOrigin(offset)
             wcs_ref = WCS(shifted_wcs.getFitsMetadata())
         else:
-            img_warped = warp_img(img_ref, img, wcs_ref, img.getWcs())
-        # fig, ax = plt.subplots(1, 1, figsize=(2, 2))
+            img_warped = warp_img(img_ref, img, img_ref.getWcs(), img.getWcs())
         im_arr = img_warped.image.array
         var_arr = img_warped.variance.array
         N1, N2 = im_arr.shape

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -164,8 +164,8 @@ def dia_source_to_scene(cutout_size_pix, dia_src, service):
     i = 0
     cutout_size_pix = 131
     cutout_size = cutout_size_pix * 0.2 / 3600.0
-    ra = dia_src["ra"]
-    dec = dia_src["decl"]
+    ra = dia_src["ra"][0]
+    dec = dia_src["decl"][0]
 
     observations = []
     channels_sc2 = []

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -261,4 +261,7 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
                 .1, .9, r'$\Delta$t='
                     + str(round(src['midPointTai']-first_time, 2)),
                     color='white', fontsize=12)
+            plt.show()
+            plt.close()
+
     return observations, channels_sc2

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -218,8 +218,7 @@ def dia_source_to_observations(cutout_size_pix, dia_src, service, plot_images=Fa
             shifted_wcs = img_ref.getWcs().copyAtShiftedPixelOrigin(offset)
             wcs_ref = WCS(shifted_wcs.getFitsMetadata())
         else:
-            img_warped = warp_img(img_ref, img, img_ref.getWcs(), img.getWcs())
-        img_warped = warp_img(img_ref, img, img_ref.getWcs(), img.getWcs())
+            img_warped = warp_img(img_ref, img, wcs_ref, img.getWcs())
         # fig, ax = plt.subplots(1, 1, figsize=(2, 2))
         im_arr = img_warped.image.array
         var_arr = img_warped.variance.array

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -197,8 +197,8 @@ def dia_source_to_scene(cutout_size_pix, dia_src, service):
             psf_sc2 = psf_ref.array.reshape(1, N1, N2)
             # maybe we can we have an option to cache the coutouts
             # filename = os.path.join(tempdir,'cutout_' + str(i) + '.fits')
-            img_ref.writeFits(filename)
-            f = fits.open(filename)
+            # img_ref.writeFits(filename)
+            # f = fits.open(filename)
             wcs_ref = WCS(f[1].header)
 
             obs = scarlet2.Observation(

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -1,60 +1,25 @@
-import time
-import numpy as np
-import uuid
-import os
-import glob
-import math
-import pandas
-import matplotlib.pyplot as plt
-import tempfile
-import getpass
-from PIL import Image
-from IPython.display import Image as dimg
-
-import lsst.geom as geom
-import lsst.resources
-import lsst.afw.display as afwDisplay
-from lsst.afw.image import Exposure, ExposureF
-from lsst.pipe.tasks.registerImage import RegisterConfig, RegisterTask
-from lsst.rsp import get_tap_service
-from lsst.rsp.utils import get_access_token
-from lsst.afw.fits import MemFileManager
-
-import pyvo
-from pyvo.dal.adhoc import DatalinkResults, SodaQuery
-
-import astropy
-from astropy import units as u
-from astropy.coordinates import SkyCoord, Angle
-from astropy.io import fits
-from astropy.wcs import WCS
-
-import scarlet2
-import matplotlib.pyplot as plt
-import numpy as np
-from scipy.optimize import curve_fit
-from scipy.stats import skew
-import getpass
-
-import lsst.daf.butler as dafButler
-import lsst.afw.display as afwDisplay
-from lsst.geom import Point2D, radToDeg, SpherePoint, degrees
-
-from astropy.wcs import WCS
-from astropy.io import fits
 import jax.numpy as jnp
 import lsst.afw.geom as afwGeom
-import lsst.afw.image as afwImage
-import lsst.afw.display as afwDisplay
-import lsst.afw.table as afwTable
 import lsst.geom as geom
-from lsst.afw.detection import Psf
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+from astropy.wcs import WCS
+from lsst.afw.fits import MemFileManager
+from lsst.afw.image import ExposureF
+from lsst.geom import Point2D
 from lsst.meas.algorithms import WarpedPsf
+from lsst.pipe.tasks.registerImage import RegisterConfig, RegisterTask
+from pyvo.dal.adhoc import DatalinkResults, SodaQuery
+
+import scarlet2
+
 
 def warp_img(ref_img, img_to_warp, ref_wcs, wcs_to_warp):
     """Warp and rotate an image onto the coordinate system of another image
 
-   Parameters
+    Parameters
     ----------
     ref_img: 'ExposureF'
         is the reference image for the re-projection
@@ -64,17 +29,17 @@ def warp_img(ref_img, img_to_warp, ref_wcs, wcs_to_warp):
         the wcs of the reference image (i.e. ref_img.getWcs() )
     wcs_to_warp: 'wcs object'
         the wcs of the image to warp (i.e. img_to_warp.getWcs() )
-   Returns
+    Returns
     -------
     warpedExp: 'ExposureF'
         a reprojected, rotated image that is aligned and matched to ref_image
-     """
+    """
     config = RegisterConfig()
     task = RegisterTask(name="register", config=config)
-    warpedExp = task.warpExposure(img_to_warp, wcs_to_warp, ref_wcs,
-                                  ref_img.getBBox())
+    warpedExp = task.warpExposure(img_to_warp, wcs_to_warp, ref_wcs, ref_img.getBBox())
 
     return warpedExp
+
 
 def read_cutout_mem(sq):
     """Read the cutout into memory
@@ -98,11 +63,11 @@ def read_cutout_mem(sq):
 
     return exposure
 
-def make_image_cutout(tap_service, ra, dec, dataId, cutout_size=0.01,
-                      imtype=None, filename=None):
+
+def make_image_cutout(tap_service, ra, dec, dataId, cutout_size=0.01, imtype=None, filename=None):
     """Wrapper function to generate a cutout using the cutout tool
 
-   Parameters
+    Parameters
     ----------
     tap_service : an instance of the TAP service
     ra, dec : 'float'
@@ -119,23 +84,27 @@ def make_image_cutout(tap_service, ra, dec, dataId, cutout_size=0.01,
     filename : 'string', optional
         filename of the resulting cutout (which has fits format)
 
-   Returns
+    Returns
     -------
     exposure : 'ExposureF'
         the cutout in exposureF format
     """
 
-    spherePoint = geom.SpherePoint(ra*geom.degrees, dec*geom.degrees)
+    spherePoint = geom.SpherePoint(ra * geom.degrees, dec * geom.degrees)
 
-    if imtype == 'calexp':
-
-        query = "SELECT access_format, access_url, dataproduct_subtype, " + \
-            "lsst_visit, lsst_detector, lsst_band " + \
-            "FROM dp02_dc2_catalogs.ObsCore WHERE dataproduct_type = 'image' " + \
-            "AND obs_collection = 'LSST.DP02' " + \
-            "AND dataproduct_subtype = 'lsst.calexp' " + \
-            "AND lsst_visit = " + str(dataId["visit"]) + " " + \
-            "AND lsst_detector = " + str(dataId["detector"])
+    if imtype == "calexp":
+        query = (
+            "SELECT access_format, access_url, dataproduct_subtype, "
+            + "lsst_visit, lsst_detector, lsst_band "
+            + "FROM dp02_dc2_catalogs.ObsCore WHERE dataproduct_type = 'image' "
+            + "AND obs_collection = 'LSST.DP02' "
+            + "AND dataproduct_subtype = 'lsst.calexp' "
+            + "AND lsst_visit = "
+            + str(dataId["visit"])
+            + " "
+            + "AND lsst_detector = "
+            + str(dataId["detector"])
+        )
         results = tap_service.search(query)
 
     else:
@@ -146,32 +115,40 @@ def make_image_cutout(tap_service, ra, dec, dataId, cutout_size=0.01,
         # add optional default band if it is not contained in the dataId
         band = dataId["band"]
 
-        query = "SELECT access_format, access_url, dataproduct_subtype, " + \
-            "lsst_patch, lsst_tract, lsst_band " + \
-            "FROM dp02_dc2_catalogs.ObsCore WHERE dataproduct_type = 'image' " + \
-            "AND obs_collection = 'LSST.DP02' " + \
-            "AND dataproduct_subtype = 'lsst.deepCoadd_calexp' " + \
-            "AND lsst_tract = " + str(tract) + " " + \
-            "AND lsst_patch = " + str(patch) + " " + \
-            "AND lsst_band = " + "'" + str(band) + "' "
+        query = (
+            "SELECT access_format, access_url, dataproduct_subtype, "
+            + "lsst_patch, lsst_tract, lsst_band "
+            + "FROM dp02_dc2_catalogs.ObsCore WHERE dataproduct_type = 'image' "
+            + "AND obs_collection = 'LSST.DP02' "
+            + "AND dataproduct_subtype = 'lsst.deepCoadd_calexp' "
+            + "AND lsst_tract = "
+            + str(tract)
+            + " "
+            + "AND lsst_patch = "
+            + str(patch)
+            + " "
+            + "AND lsst_band = "
+            + "'"
+            + str(band)
+            + "' "
+        )
         results = tap_service.search(query)
 
     # Get datalink
     dataLinkUrl = results[0].getdataurl()
     auth_session = tap_service._session
     print(dataLinkUrl)
-    dl = DatalinkResults.from_result_url(dataLinkUrl,
-                                         session=auth_session)
+    dl = DatalinkResults.from_result_url(dataLinkUrl, session=auth_session)
 
     # from_resource: creates a instance from
     # a number of records and a Datalink Resource.
-    sq = SodaQuery.from_resource(dl,
-                                 dl.get_adhocservice_by_id("cutout-sync"),
-                                 session=auth_session)
+    sq = SodaQuery.from_resource(dl, dl.get_adhocservice_by_id("cutout-sync"), session=auth_session)
 
-    sq.circle = (spherePoint.getRa().asDegrees() * u.deg,
-                 spherePoint.getDec().asDegrees() * u.deg,
-                 cutout_size * u.deg)
+    sq.circle = (
+        spherePoint.getRa().asDegrees() * u.deg,
+        spherePoint.getDec().asDegrees() * u.deg,
+        cutout_size * u.deg,
+    )
 
     exposure = read_cutout_mem(sq)
 
@@ -179,90 +156,97 @@ def make_image_cutout(tap_service, ra, dec, dataId, cutout_size=0.01,
     # mem = MemFileManager(len(cutout_bytes))
     # mem.setData(cutout_bytes, len(cutout_bytes))
     # exposure = ExposureF(mem)
-    
+
     return exposure
+
 
 def dia_source_to_scene(cutout_size_pix, dia_src, service):
     i = 0
     cutout_size_pix = 131
     cutout_size = cutout_size_pix * 0.2 / 3600.0
-    ra = dia_src['ra']
-    dec = dia_src['decl']
+    ra = dia_src["ra"]
+    dec = dia_src["decl"]
 
-    observations=[]
-    channels_sc2=[]
-    for i,src in enumerate(dia_src):
-        ccdvisitID = src['ccdVisitId']
-        band = str(src['filterName'])
+    observations = []
+    channels_sc2 = []
+    for i, src in enumerate(dia_src):
+        ccdvisitID = src["ccdVisitId"]
+        band = str(src["filterName"])
         visit = str(ccdvisitID)[:-3]
         detector = str(ccdvisitID)[-3:]
         visit = int(visit)
         detector = int(detector)
-        dataId_calexp = {'visit': visit, 'detector': detector} 
-        
+        dataId_calexp = {"visit": visit, "detector": detector}
+
         if i == 0:
-            img_ref = make_image_cutout(service, ra, dec, cutout_size=cutout_size,
-                                        imtype='calexp', dataId=dataId_calexp)      
-            im_arr = img_ref.image.array                                   
-            var_arr = img_ref.variance.array                                    
-            N1,N2 = im_arr.shape
-            image_sc2 = im_arr.reshape(1, N1,N2)
-            N1,N2 = var_arr.shape
-            weight_sc2 = 1/var_arr.reshape(1, N1,N2)
+            img_ref = make_image_cutout(
+                service, ra, dec, cutout_size=cutout_size, imtype="calexp", dataId=dataId_calexp
+            )
+            im_arr = img_ref.image.array
+            var_arr = img_ref.variance.array
+            N1, N2 = im_arr.shape
+            image_sc2 = im_arr.reshape(1, N1, N2)
+            N1, N2 = var_arr.shape
+            weight_sc2 = 1 / var_arr.reshape(1, N1, N2)
             info_calexp = img_ref.getInfo()
             psf_calexp = info_calexp.getPsf()
-            point_tuple = (int(img_ref.image.array.shape[0]/2),int(img_ref.image.array.shape[1]/2))
+            point_tuple = (int(img_ref.image.array.shape[0] / 2), int(img_ref.image.array.shape[1] / 2))
             point_image = Point2D(point_tuple)
             psf_ref = psf_calexp.computeImage(point_image).convertF()
-            N1,N2 = psf_ref.array.shape
-            psf_sc2 = psf_ref.array.reshape(1, N1,N2)
+            N1, N2 = psf_ref.array.shape
+            psf_sc2 = psf_ref.array.reshape(1, N1, N2)
             # maybe we can we have an option to cache the coutouts
             # filename = os.path.join(tempdir,'cutout_' + str(i) + '.fits')
             img_ref.writeFits(filename)
-            f=fits.open(filename)
+            f = fits.open(filename)
             wcs_ref = WCS(f[1].header)
 
-            obs = scarlet2.Observation(jnp.array(image_sc2).astype(float),
-                            weights=jnp.array(weight_sc2).astype(float),
-                            psf=scarlet2.ArrayPSF(jnp.array(psf_sc2).astype(float)),
-                            wcs=wcs_ref,
-                            channels=[(band,str(i))])
-            channels_sc2.append((band,str(i)))
+            obs = scarlet2.Observation(
+                jnp.array(image_sc2).astype(float),
+                weights=jnp.array(weight_sc2).astype(float),
+                psf=scarlet2.ArrayPSF(jnp.array(psf_sc2).astype(float)),
+                wcs=wcs_ref,
+                channels=[(band, str(i))],
+            )
+            channels_sc2.append((band, str(i)))
             observations.append(obs)
         else:
-            img = make_image_cutout(service, ra, dec, cutout_size=cutout_size*50.0,
-                                    imtype='calexp', dataId=dataId_calexp)
+            img = make_image_cutout(
+                service, ra, dec, cutout_size=cutout_size * 50.0, imtype="calexp", dataId=dataId_calexp
+            )
             img_warped = warp_img(img_ref, img, img_ref.getWcs(), img.getWcs())
             fig, ax = plt.subplots(1, 1, figsize=(2, 2))
             im_arr = img_warped.image.array
             var_arr = img_warped.variance.array
-            N1,N2 = im_arr.shape
-            image_sc2 = im_arr.reshape(1, N1,N2)
-            N1,N2 = var_arr.shape
-            weight_sc2 = 1/var_arr.reshape(1, N1,N2)
+            N1, N2 = im_arr.shape
+            image_sc2 = im_arr.reshape(1, N1, N2)
+            N1, N2 = var_arr.shape
+            weight_sc2 = 1 / var_arr.reshape(1, N1, N2)
             info_calexp = img.getInfo()
             psf_calexp = info_calexp.getPsf()
-            point_tuple = (int(img_warped.image.array.shape[0]/2),int(img_warped.image.array.shape[1]/2))
+            point_tuple = (int(img_warped.image.array.shape[0] / 2), int(img_warped.image.array.shape[1] / 2))
             point_image = Point2D(point_tuple)
             psf = psf_calexp.computeImage(point_image).convertF()
-            xyTransform = afwGeom.makeWcsPairTransform(img.wcs,img_warped.wcs)
+            xyTransform = afwGeom.makeWcsPairTransform(img.wcs, img_warped.wcs)
             psf_w = WarpedPsf(img.getPsf(), xyTransform)
-            point_tuple = (int(img_warped.image.array.shape[0]/2),int(img_warped.image.array.shape[1]/2))
+            point_tuple = (int(img_warped.image.array.shape[0] / 2), int(img_warped.image.array.shape[1] / 2))
             point_image = Point2D(point_tuple)
             psf_warped = psf_w.computeImage(point_image).convertF()
-            if np.sum(psf_warped.array)==0:
-                print('PSF model unavailable, skipping')
+            if np.sum(psf_warped.array) == 0:
+                print("PSF model unavailable, skipping")
                 continue
-            N1,N2 = psf_warped.array.shape
-            psf_sc2 = psf_warped.array.reshape(1, N1,N2)
+            N1, N2 = psf_warped.array.shape
+            psf_sc2 = psf_warped.array.reshape(1, N1, N2)
             # filename = os.path.join(tempdir, 'cutout_' + str(i) + '.fits')
             # img_ref.writeFits(filename)
             # f=fits.open(filename)
             wcs = WCS(f[1].header)
-            obs = scarlet2.Observation(jnp.array(image_sc2).astype(float),
-                            weights=jnp.array(weight_sc2).astype(float),
-                            psf=scarlet2.ArrayPSF(jnp.array(psf_sc2).astype(float)),
-                            wcs=wcs,
-                            channels=[(band,str(i))])
-            channels_sc2.append((band,str(i)))
+            obs = scarlet2.Observation(
+                jnp.array(image_sc2).astype(float),
+                weights=jnp.array(weight_sc2).astype(float),
+                psf=scarlet2.ArrayPSF(jnp.array(psf_sc2).astype(float)),
+                wcs=wcs,
+                channels=[(band, str(i))],
+            )
+            channels_sc2.append((band, str(i)))
             observations.append(obs)

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -250,3 +250,4 @@ def dia_source_to_scene(cutout_size_pix, dia_src, service):
             )
             channels_sc2.append((band, str(i)))
             observations.append(obs)
+    return observations, channels_sc2

--- a/src/scarlet2/lsst_utils.py
+++ b/src/scarlet2/lsst_utils.py
@@ -1,7 +1,8 @@
+import os
+
 import jax.numpy as jnp
 import lsst.afw.geom as afwGeom
 import lsst.geom as geom
-import matplotlib.pyplot as plt
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
@@ -14,8 +15,6 @@ from lsst.pipe.tasks.registerImage import RegisterConfig, RegisterTask
 from pyvo.dal.adhoc import DatalinkResults, SodaQuery
 
 import scarlet2
-
-import os
 
 
 def warp_img(ref_img, img_to_warp, ref_wcs, wcs_to_warp):
@@ -182,7 +181,7 @@ def dia_source_to_scene(cutout_size_pix, dia_src, service, tempdir):
         img_ref = None
 
         img = make_image_cutout(
-                service, ra, dec, cutout_size=cutout_size * 50.0, imtype="calexp", dataId=dataId_calexp
+            service, ra, dec, cutout_size=cutout_size * 50.0, imtype="calexp", dataId=dataId_calexp
         )
         if i == 0:
             img_ref = img
@@ -215,9 +214,9 @@ def dia_source_to_scene(cutout_size_pix, dia_src, service, tempdir):
         psf_sc2 = psf_warped.array.reshape(1, N1, N2)
         # this is required to get the WCS, we should figure out a better
         # way to do this without writing to disk
-        filename = os.path.join(tempdir, 'cutout_' + str(i) + '.fits')
+        filename = os.path.join(tempdir, "cutout_" + str(i) + ".fits")
         img_ref.writeFits(filename)
-        f=fits.open(filename)
+        f = fits.open(filename)
         wcs = WCS(f[1].header)
         obs = scarlet2.Observation(
             jnp.array(image_sc2).astype(float),


### PR DESCRIPTION
take some of @charlotteaward 's code from the `TDdemo_RSP` notebook and make it more readily available as part of the `scarlet2` package. mainly meant to be used on the RSP. creates:

- `warp_img` - a simple warping function that takes in two exposures and warps the second to match the wcs of the first
- `read_cutout_mem` - read an exposure into memory from a query
- `make_image_cutout` - generate an image using the LSST cutout tool
- `dia_source_to_observations` - take a diaSrc table, get the needed data, warp it based on the first image, then load that into a list of `scarlet2` `Observations`.