### PR TITLE
Clean up docstrings and type hints in validation files

### DIFF
--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -252,8 +252,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         if self.observation.weights is not None and (self.observation.weights < 0).any():
             return ValidationError(
@@ -272,8 +272,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         if self.observation.weights is not None and jnp.isinf(self.observation.weights).any():
             return ValidationError(
@@ -292,8 +292,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         if (
             self.observation.weights is not None
@@ -322,8 +322,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         num_channels = len(self.observation.frame.channels)
         if num_channels != self.observation.data.shape[0]:
@@ -347,8 +347,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         if self.observation.weights is not None and self.observation.data is not None:
             # Mask self.observation.data where self.observation.weights is 0
@@ -378,8 +378,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         if self.observation.frame.psf is not None:
             psf = self.observation.frame.psf()
@@ -408,8 +408,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         return_value: ValidationResult = ValidationInfo(
             message="Number of PSF channels matches the number of data channels.",
@@ -445,8 +445,8 @@ class ObservationValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         return_value: ValidationResult = ValidationInfo(
             message="PSF centroid is consistent across channels.",

--- a/src/scarlet2/scene.py
+++ b/src/scarlet2/scene.py
@@ -550,22 +550,13 @@ class FitValidator(metaclass=ValidationMethodCollector):
 
     def check_goodness_of_fit(self) -> ValidationResult:
         """Evaluate the goodness of the model fit to the data by calling the Observation
-        class's `goodness_of_fit` method.
-
-        For a Gaussian noise model, the gof is defined as the averaged squared deviation of the model from the
-        data, scaled by the variance of the data, aka mean chi squared
-        :math:`\frac{1}{N}\\sum_i=1^N w_i (m_i - d_i)^2` with inverse variance weights :math:`w_i`.
-
-        Up to a normalization, the gof is identical to :py:class:`~scarlet2.Observation.log-likelihood`.
-
-        Parameters
-        ----------
-        model: array
-            The (pre-rendered) predicted data cube, typically from evaluating :py:class:`~scarlet2.Scene`
+        class's `goodness_of_fit` method. Please see the docstring for that method
+        for details.
 
         Returns
         -------
-        float
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         obs = self.observation
 
@@ -592,9 +583,10 @@ class FitValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        None or ValidationError
-            If the chi-square is above the tolerable threshold, returns a ValidationError.
-            Otherwise, returns None.
+        ValidationResult
+            If the chi-square is above the critical threshold, returns a ValidationError.
+            If the chi-square is below the tolerable threshold, returns a ValidationInfo.
+            If the chi-square is between the two thresholds, returns a ValidationWarning.
         """
         obs = self.observation
 

--- a/src/scarlet2/source.py
+++ b/src/scarlet2/source.py
@@ -270,8 +270,8 @@ class SourceValidator(metaclass=ValidationMethodCollector):
 
         Returns
         -------
-        ValidationError or None
-            Returns a ValidationError if the check fails, otherwise None.
+        ValidationResult
+            A subclass of ValidationResult indicating the result of the check.
         """
         model = self.source()
         if jnp.any(model < 0):


### PR DESCRIPTION
There are no changes to logic in this PR, it is strictly correcting type hints and docstrings to reflect what the code is actually doing. Also updated a couple variable names in validation.py for the same purpose. 