### PR TITLE
Enabling auto-validation in quickstart notebook

### DIFF
--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -19,9 +19,7 @@
     "import jax.numpy as jnp\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from scarlet2 import *\n",
-    "\n",
-    "set_validation(False)"
+    "from scarlet2 import *"
    ]
   },
   {
@@ -104,7 +102,14 @@
    "source": [
     "_scarlet2_ will construct another {py:class}`~scarlet2.Frame` for the _model_ of the sky you seek to fit. It differs from the observation frame because the model needs to be superior in terms of spatial resolution, PSF blurring, spectral coverage, or all of the above, so that the observation can be computed from the model by a degradation operation, the so-called \"forward operator. In _scarlet2_, {py:class}`~scarlet2.renderer.Renderer` implements this operation and contains, e.g., PSF difference kernels and resampling transformations.\n",
     "\n",
-    "In this example, we assume that bands and pixel locations are identical between the model and the observation. Because we have ground-based images, the degradation comes from the PSF. With different PSFs in each band, we need to define a reference PSF that is sufficiently narrow. Our default is minimal Gaussian PSF that is barely well-sampled (standard deviation of 0.7 pixels) as our reference kernel:"
+    "In this example, we assume that bands and pixel locations are identical between the model and the observation. Because we have ground-based images, the degradation comes from the PSF. With different PSFs in each band, we need to define a reference PSF that is sufficiently narrow. Our default is minimal Gaussian PSF that is barely well-sampled (standard deviation of 0.7 pixels) as our reference kernel:\n",
+    "\n",
+    "Note also the validation results that are automatically generated.\n",
+    "These are executed automatically on behalf of the user and act as guardrails.\n",
+    "Here we can see that check number ``007`` produced a error and prints a message indicating that the PSF is not the same for all channels.\n",
+    "While validation errors will not cause the code to stop running, they do indicate a likely problem that warrants attention.\n",
+    "Automatic validation is performed at several times in ``scarlet2``, which can be seen later in this notebook.\n",
+    "For additional information about automatic validation, please see the \"Validation\" section of the documentation."
    ]
   },
   {
@@ -639,18 +644,36 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see the two new sources 7 and 8, and that most of the other features are very similar to before. As expected, the residuals have visibly improved where we added the source and are now dominated by a red-blue pattern in the center of source 1, which we should probably fit with 2 components."
+    "We can see the two new sources 7 and 8, and that most of the other features are very similar to before. As expected, the residuals have visibly improved where we added the source and are now dominated by a red-blue pattern in the center of source 1, which we should probably fit with 2 components.\n",
+    "\n",
+    "Notice in plot on the right, source 0 has a slight magenta highlight just right of center.\n",
+    "If you'll recall when we created the Observation object a validation check produced an error that indicated misaligned PSF centroids.\n",
+    "That PSF centroid misalignment is the likely cause of the missed flux."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "scarlet2",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is meant to take care of:
- Enable automatic validation in the quickstart notebook for showcasing
- Add comments describing how auto-validation helps, where to go for more info.
- Noting in the later cells how the ValidationError reported when `obs` was created helps identify a problem later on.