### PR TITLE
decreased min_snr to 3; more stable testing for Gaussian shape

### DIFF
--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -200,7 +200,7 @@
     "with sc2.Scene(model_frame) as scene:\n",
     "    for center in centers:\n",
     "        try:\n",
-    "            spectrum, morph = sc2.init.from_gaussian_moments(obs, center, min_corr=0.99)\n",
+    "            spectrum, morph = sc2.init.from_gaussian_moments(obs, center)\n",
     "        except ValueError:\n",
     "            spectrum = sc2.init.pixel_spectrum(obs, center)\n",
     "            morph = sc2.init.compact_morphology()\n",
@@ -228,7 +228,7 @@
     "            sc2.PointSource(center, spectrum)\n",
     "        else:\n",
     "            try:\n",
-    "                spectrum, morph = sc2.init.from_gaussian_moments(obs, center, min_corr=0.99)\n",
+    "                spectrum, morph = sc2.init.from_gaussian_moments(obs, center)\n",
     "            except ValueError:\n",
     "                spectrum = sc2.init.pixel_spectrum(obs, center)\n",
     "                morph = sc2.init.compact_morphology()\n",
@@ -254,6 +254,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sc2.plot.scene(\n",
+    "    scene,\n",
+    "    obs,\n",
+    "    norm=norm,\n",
+    "    show_model=True,\n",
+    "    show_rendered=True,\n",
+    "    show_observed=True,\n",
+    "    show_residual=True,\n",
+    "    add_boxes=True,\n",
+    ");\n",
     "print(scene)"
    ]
   },
@@ -261,8 +271,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`scene` contains the `frame` and the list `sources`. The first source is indeed a {py:class}`~scarlet2.PointSource`, which has a `morphology` model, namely the same {py:class}`~scarlet2.GaussianMorphology` as the PSF of the model frame.\n",
-    " All others are standard {py:class}`~scarlet2.Source`s. The data portions in these models are listed as, e.g., `f32[11,11]`, which denotes an image array of 11x11 pixels. The size of these boxes was determined by {py:func}`scarlet2.init.from_gaussian_moments` to contain most of the flux (or the largest box that seems to be occupied by only one source)."
+    "`scene` contains the `frame` and the list `sources`. The first source is a {py:class}`~scarlet2.PointSource`, which has a `morphology` model, namely the same {py:class}`~scarlet2.GaussianMorphology` as the PSF of the model frame.\n",
+    " All others are standard {py:class}`~scarlet2.Source`s. The data portions in these models are listed as, e.g., `f32[11,11]`, which denotes an image array of 11x11 pixels. The size of these boxes was determined by {py:func}`scarlet2.init.from_gaussian_moments` to contain most of the flux (or the largest box that seems to be occupied by only one source).\n",
+    "\n",
+    "But these initial choices are not great. So, we now have to..."
    ]
   },
   {
@@ -413,8 +425,7 @@
     "    show_observed=True,\n",
     "    show_residual=True,\n",
     "    add_boxes=True,\n",
-    ")\n",
-    "plt.show()"
+    ");"
    ]
   },
   {

--- a/docs/howto/correlated.ipynb
+++ b/docs/howto/correlated.ipynb
@@ -14,12 +14,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "001b20ac-1502-4c15-8153-2a71ddc6f556",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:38:58.444250Z",
-     "start_time": "2025-11-26T03:38:56.884402Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import astropy.io.fits as fits\n",
@@ -49,12 +44,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b8eb94ba-1ea5-45ba-b4f5-689f6abe7d9e",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T04:03:12.443907Z",
-     "start_time": "2025-11-26T04:03:12.138612Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from huggingface_hub import hf_hub_download\n",
@@ -102,12 +92,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9b517930-9941-470e-981c-eb6deb49c4bc",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:39:02.010219Z",
-     "start_time": "2025-11-26T03:38:58.782798Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Scarlet Observations\n",
@@ -131,12 +116,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2f85eb1bdac3efac",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T04:10:29.079105Z",
-     "start_time": "2025-11-26T04:10:29.001966Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
@@ -161,12 +141,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6e153b6f57dc6bcf",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T04:19:25.910481Z",
-     "start_time": "2025-11-26T04:19:23.317454Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "obs_corr = sc2.CorrelatedObservation.from_observation(obs_hst)"
@@ -186,18 +161,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bf35ea14-5181-4427-b1fc-414ce114f137",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T15:30:01.105539Z",
-     "start_time": "2025-11-26T15:30:00.843171Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with sc2.Scene(model_frame) as scene:\n",
     "    for i, center in enumerate(ra_dec):\n",
     "        try:\n",
-    "            spectrum, morph = sc2.init.from_gaussian_moments(obs_hst, center, min_snr=1)\n",
+    "            spectrum, morph = sc2.init.from_gaussian_moments(obs_hst, center, min_snr=2)\n",
     "        except ValueError:\n",
     "            spectrum = sc2.init.pixel_spectrum(obs_hst, center)\n",
     "            morph = sc2.init.compact_morphology()\n",
@@ -208,12 +178,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5db7b15f9e478c17",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:39:37.432596Z",
-     "start_time": "2025-11-26T03:39:36.161552Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc2.plot.scene(\n",
@@ -233,12 +198,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c65689f5b32a6207",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:39:43.117131Z",
-     "start_time": "2025-11-26T03:39:42.210100Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from numpyro.distributions import constraints\n",
@@ -249,13 +209,13 @@
     "\n",
     "with sc2.Parameters(scene) as parameters:\n",
     "    for i in range(len(scene.sources)):\n",
-    "        parameters += sc2.Parameter(\n",
+    "        sc2.Parameter(\n",
     "            scene.sources[i].spectrum,\n",
     "            name=f\"spectrum.{i}\",\n",
     "            constraint=constraints.positive,\n",
     "            stepsize=spec_step\n",
     "        )\n",
-    "        parameters += sc2.Parameter(\n",
+    "        sc2.Parameter(\n",
     "            scene.sources[i].morphology,\n",
     "            name=f\"morph.{i}\",\n",
     "            constraint=constraints.unit_interval,\n",
@@ -277,12 +237,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e7c572a736b53496",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:40:25.069132Z",
-     "start_time": "2025-11-26T03:40:19.233789Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "scene_ = scene.fit(obs_hst, parameters, max_iter=1000, progress_bar=True)"
@@ -292,12 +247,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "558cb3d3f9deefc0",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:40:27.905062Z",
-     "start_time": "2025-11-26T03:40:27.510168Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc2.plot.scene(\n",
@@ -328,12 +278,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d50ffdd-147b-4142-a3e5-b0c278283fb8",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:40:44.464987Z",
-     "start_time": "2025-11-26T03:40:38.306735Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "scene_corr = scene.fit(obs_corr, parameters, max_iter=1000, progress_bar=True)"
@@ -343,12 +288,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ce1490b2cf9c3775",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-11-26T03:40:47.368926Z",
-     "start_time": "2025-11-26T03:40:46.977969Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc2.plot.scene(\n",


### PR DESCRIPTION
minor tweaks to the initialization from moments: reduced the SNR limit at the edge of the box to 3; and test for sensible 2nd moments as part of the box definition, not afterwards. Should produce more sensible boxes.

The method `init.from_gaussian_moments` is still brittle if there are other sources in the vicinity. We need to improve this for blended groups.