### PR TITLE
Initial editorial tweaks for publication in JOSS

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -9,13 +9,15 @@
     year = 2013,
     month = oct,
     volume = 558,
+    eid = {A33},
+    pages = {A33},
     doi = {10.1051/0004-6361/201322068},
     url = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A}
 }
 
 @ARTICLE{oldag-2024,
     author = {{Oldag}, Drew and {DeLucchi}, Melissa and {Beebe}, Wilson and {Branton}, Doug and {Campos}, Sandro and {Chandler}, Colin Orion and {Christofferson}, Carl and {Connolly}, Andrew and {Kubica}, Jeremy and {Lynn}, Olivia and {Malanchev}, Konstantin and {Malz}, Alex I. and {Mandelbaum}, Rachel and {McGuire}, Sean and {Wenneman}, Chris},
-    title = "{A Python Project Template for Healthy Scientific Software}",
+    title = {A {Python} Project Template for Healthy Scientific Software},
     journal = {Research Notes of the American Astronomical Society},
     keywords = {Open source software, 1866},
     year = 2024,
@@ -31,7 +33,7 @@
 
 @ARTICLE{siegel-2025,
        author = {{Siegel}, Jared C. and {Melchior}, Peter},
-        title = "{Spatially Resolved Galaxy{\textendash}Dust Modeling with Coupled Data-driven Priors}",
+        title = {Spatially Resolved Galaxy{\textendash}Dust Modeling with Coupled Data-driven Priors},
       journal = {The Astrophysical Journal},
      keywords = {Interstellar dust extinction, Neural networks, Extragalactic astronomy, 837, 1933, 506, Astrophysics - Astrophysics of Galaxies, Astrophysics - Instrumentation and Methods for Astrophysics},
          year = 2025,
@@ -106,6 +108,7 @@ archivePrefix = {arXiv},
   title={Composable Effects for Flexible and Accelerated Probabilistic Programming in NumPyro},
   author={Phan, Du and Pradhan, Neeraj and Jankowiak, Martin},
   journal={arXiv preprint arXiv:1912.11554},
+  doi={10.48550/arXiv.1912.11554},
   year={2019}
 }
 
@@ -139,7 +142,10 @@ archivePrefix = {arXiv},
 @article{kidger2021equinox,
   author = {Kidger, Patrick and Garcia, Cristian},
   title = {Equinox: neural networks in JAX via callable PyTrees and filtered transformations},
-  journal = {arXiv preprint arXiv:2111.00254},
+  journal = {Differentiable Programming workshop at Neural Information Processing Systems 2021},
+  doi = {10.48550/arXiv.2111.00254},
+  archivePrefix = {arXiv},
+  eprint = {2111.00254},
   year = {2021}
 }
 
@@ -152,7 +158,7 @@ archivePrefix = {arXiv},
 
 @ARTICLE{yao-2025,
        author = {{Yao}, Yuhan and {Chornock}, Ryan and {Ward}, Charlotte and {Hammerstein}, Erica and {Sfaradi}, Itai and {Margutti}, Raffaella and {Kelley}, Luke Zoltan and {Lu}, Wenbin and {Liu}, Chang and {Wise}, Jacob and {Sollerman}, Jesper and {Alexander}, Kate D. and {Bellm}, Eric C. and {Drake}, Andrew J. and {Fremling}, Christoffer and {Gilfanov}, Marat and {Graham}, Matthew J. and {Groom}, Steven L. and {Hinds}, K.~R. and {Kulkarni}, S.~R. and {Miller}, Adam A. and {Miller-Jones}, James C.~A. and {Nicholl}, Matt and {Perley}, Daniel A. and {Purdum}, Josiah and {Ravi}, Vikram and {Rich}, R. Michael and {Rehemtulla}, Nabeel and {Riddle}, Reed and {Smith}, Roger and {Stein}, Robert and {Sunyaev}, Rashid and {van Velzen}, Sjoert and {Wold}, Avery},
-        title = "{A Massive Black Hole 0.8 kpc from the Host Nucleus Revealed by the Offset Tidal Disruption Event AT2024tvd}",
+        title = {A Massive Black Hole 0.8 kpc from the Host Nucleus Revealed by the Offset Tidal Disruption Event {AT2024tvd}},
       journal = {The Astrophysical Journal Letters},
      keywords = {Tidal disruption, X-ray transient sources, Supermassive black holes, Time domain astronomy, Galaxy mergers, 1696, 1852, 1663, 2109, 608, Astrophysics of Galaxies, High Energy Astrophysical Phenomena},
          year = 2025,
@@ -171,7 +177,7 @@ archivePrefix = {arXiv},
 
 @ARTICLE{galfit,
        author = {{Peng}, Chien Y. and {Ho}, Luis C. and {Impey}, Chris D. and {Rix}, Hans-Walter},
-        title = "{Detailed Structural Decomposition of Galaxy Images}",
+        title = {Detailed Structural Decomposition of Galaxy Images},
       journal = {The Astronomical Journal},
      keywords = {Galaxies: Bulges, Galaxies: Fundamental Parameters, Galaxies: Nuclei, Galaxies: Structure, Techniques: Image Processing, Techniques: Photometric, Astrophysics},
          year = 2002,
@@ -238,16 +244,19 @@ archivePrefix = {ascl},
 
 @ARTICLE{astrophot,
        author = {{Stone}, Connor J. and {Courteau}, St{\'e}phane and {Cuillandre}, Jean-Charles and {Hezaveh}, Yashar and {Perreault-Levasseur}, Laurence and {Arora}, Nikhil},
-        title = "{AstroPhot: Fitting Everything Everywhere All at Once in Astronomical Images}",
+        title = {{AstroPhot}: Fitting Everything Everywhere All at Once in Astronomical Images},
       journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {galaxies: general, galaxies: photometry, stars: imaging, software: data analysis, techniques: image processing, techniques: photometric, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Astrophysics of Galaxies, Astrophysics - Solar and Stellar Astrophysics},
          year = 2023,
-        month = aug,
+        month = nov,
+       volume = {525},
+       number = {4},
+        pages = {6377-6393},
           doi = {10.1093/mnras/stad2477},
 archivePrefix = {arXiv},
        eprint = {2308.01957},
  primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.tmp.2330S},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2023MNRAS.525.6377S},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -31,10 +31,10 @@ affiliations:
   - name: Princeton University, United States
     index: 1
     ror: 00hx57361
-  - name: Pennsylvania State University
+  - name: Pennsylvania State University, United States
     index: 2
     ror: 04p491231
-  - name: University of Chicago
+  - name: University of Chicago, United States
     index: 3
     ror: 024mw5h28
 
@@ -64,27 +64,27 @@ components, and each component is determined by a spectrum model and a morpholog
 represents the light
 emission in a sky region as a hyperspectral data cube (wavelength $\times$ height $\times$ width). `scarlet2` retains
 the object-oriented paradigm and many classes and functions from `scarlet`, but augments standard Python with the JAX 
-library [@jax2018github] and the `equinox` package [@kidger2021equinox] for automatic differentiation and
+library [@jax2018github] and the Equinox package [@kidger2021equinox] for automatic differentiation and
 just-in-time compilation.
 
 `scarlet2` acts as a flexible, modular, and extendable modeling language for celestial sources that combines parametric
 and non-parametric models to describe complex scenarios such as multi-source blending, strong-lensing systems,
 supernovae and their host galaxies, etc. As a modeling language, `scarlet2` is agnostic about the optimization or
 inference method the user wants to employ, but it also provides methods to optimize the likelihood function or
-sample from the posterior, which utilize the `optax` package [@deepmind2020jax] or the `numpyro` inference
+sample from the posterior, which utilize the Optax package [@deepmind2020jax] or the NumPyro inference
 framework
 [@pyro-2019; @phan-2019], respectively. The likelihood of multiple
 observations (at different resolutions, wavelengths, or observing epochs) can be combined for a joint model of
-static and transient sources. To match the coordinates from different observations, `scarlet2` utilizes the `Astropy`
+static and transient sources. To match the coordinates from different observations, `scarlet2` utilizes the Astropy
 package [@astropy]. `scarlet2` can also interface with deep learning methods. Besides being natively portable
 to GPUs, parameters can be specified with neural networks as data-driven priors, which helps break the
 degeneracies that arise
 when multiple components are fit simultaneously [@sampson-2024].
 
 ![Scene with seven detected sources in multi-band images from the Hyper Suprime-Cam Subaru Strategic Program.
-Each source is modelled with a non-parametric spectrum and morphology (1st panel), the entire scene is then convolved
-with the telescope's point spread function (2nd panel) and compared to the observations (3rd panel).
-The residuals (4th panel) reveal the presence of previously undetected sources and source components (e.g. in the center of source
+Each source is modelled with a non-parametric spectrum and morphology (first panel), the entire scene is then convolved
+with the telescope's point spread function (second panel) and compared to the observations (third panel).
+The residuals (fourth panel) reveal the presence of previously undetected sources and source components (e.g. in the center of source
 #1).](scarlet2_model.png)
 
 To support the wide range of scientific studies that will be made with large sky surveys, `scarlet2` was designed with
@@ -101,9 +101,9 @@ the La Silla Schmidt Southern Survey.
 
 `GALFIT` [@galfit] implements parametric Sérsic model fitting in single-band, single-epoch data. The underlying algorithms are closed source and released only as precompiled binaries. 
 `GALAPAGOS` [@galapagos] provides wrappers around `GAFLIT` in the proprietary IDL programming language; `GALAPAGOS-2` [@galapagos2] added multi-band fitting capabilities. 
-`The Tractor` [@tractor] is implemented in python and allows modeling galaxies in multi-band imaging at different resolutions as well as posterior sampling, but remains limited to parametric source profiles. 
-`AstroPhot` [@astrophot] offers an astronomical modeling framework based on PyTorch [@pytorch], which 
-allows to optimize multiple sources with different parametric models to multiple images at different resolutions, and includes posterior sampling techniques.
+The Tractor [@tractor] is implemented in Python and allows modeling galaxies in multi-band imaging at different resolutions as well as posterior sampling, but remains limited to parametric source profiles. 
+AstroPhot [@astrophot] offers an astronomical modeling framework based on PyTorch [@pytorch], which 
+allows one to optimize multiple sources with different parametric models to multiple images at different resolutions, and includes posterior sampling techniques.
 None of the implementations above support fully non-parametric galaxy models or neural network priors.
 
 
@@ -116,6 +116,6 @@ particular from software engineers Max West, Drew Oldag, and Sean McGuire, in ad
 through the Python Project Template [@oldag-2024] and creating a user-focused recommendation and validation
 suite.
 
-In addition to dependencies mentioned earlier, `scarlet2` makes use of `numpy` [@numpy], `matplotlib` [@matplotlib], and `h5py` [@h5py]. 
+In addition to dependencies mentioned earlier, `scarlet2` makes use of NumPy [@numpy], Matplotlib [@matplotlib], and h5py [@h5py]. 
 
 # References


### PR DESCRIPTION
This is an initial set of editorial tweaks to the JOSS paper following the [successful review](https://github.com/openjournals/joss-reviews/issues/9646). Most of these are to the citation style, including filling in a few pieces of missing data. If you're happy with the changes and merge them (or selectively apply some yourself), I'll launch another test run of our publication pipeline to double-check I haven't missed anything else.

Note that the Zenodo archive still needs its title to be changed from "jax" to "JAX" to match the updated paper, too.