### PR TITLE
better WCS defaults

### DIFF
--- a/docs/0-example.ipynb
+++ b/docs/0-example.ipynb
@@ -169,7 +169,8 @@
    "metadata": {},
    "source": [
     "If only one observation is given (as above), we assume that bands and pixel locations are identical between the model and the observation. Because we have ground-based images, we need to account for different PSFs in each band, which means the model frame needs to define a reference PSF that is sufficiently narrow. Our default is a minimal Gaussian PSF that is barely well-sampled (standard deviation of 0.7 pixels) as the PSF reference.\n",
-    "If other properties of the model frame are desired, they can be provided to {py:func}`scarlet2.Frame.from_observations`.\n",
+    "Because we didn't provide a WCS for the observation, the code will automatically create a dummy WCS with a 1-arcsec pixel scale and an intentionally unsual pseudo-Euclidean Carée projection.\n",
+    "If the model frame should have other properties, they can be overwritten through arguments to {py:func}`scarlet2.Frame.from_observations`.\n",
     "\n",
     "But what's the point of the model frame? Why is it needed at all?\n",
     "\n",

--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -119,7 +119,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "As you can see, the frame contains the size of the data array, [WCS information](https://docs.astropy.org/en/latest/wcs/index.html) on what area of the sky is being described (it's trivial here: RA/DEC = 0,0), and the description of the channels in the observation.\n",
+    "As you can see, the frame contains the size of the data array, [WCS information](https://docs.astropy.org/en/latest/wcs/index.html) on what area of the sky is being described (it's a dummy here: RA/DEC = (180,0) with 1 arcsec resolution), and the list of channels in the observation.\n",
     "\n",
     "In _scarlet2_, we use the term \"channel\" for any dimension that is not in the plane of the sky. It could be photometric bands (like the three bands in this example), spectroscopic wavelengths, and/or [time](howto/timedomain). I's the third axis of the image cube.\n",
     "\n",
@@ -412,9 +412,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/scarlet2/frame.py
+++ b/src/scarlet2/frame.py
@@ -402,8 +402,11 @@ def _wcs_default(shape):
     shape_ = shape[-2:][::-1]  # x/y
     wcs = astropy.wcs.WCS(naxis=2)
     wcs._naxis = shape_
-    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
-    wcs.wcs.crpix = jnp.array((shape_[0] // 2, shape_[1] // 2)) + 1  # 1-based pixel coordinates
+    wcs.wcs.crpix = [shape_[0] // 2 + 1, shape_[1] // 2 + 1]  # 1-based pixel coordinates
+    wcs.wcs.ctype = ["RA---CAR", "DEC--CAR"]  # Pseudo-Euclidean
+    wcs.wcs.crval = [180.0, 0.0]  # Avoid wrapping at RA=0, Dec=0 for Caree
+    wcs.wcs.cdelt = [-0.000278, 0.000278]  # 1 arcsec/pixel
+    wcs.wcs.cunit = ["deg", "deg"]
     return wcs
 
 


### PR DESCRIPTION
## Change Description

The WCS dummy we create when no WCS information is provided can create problems. It used 1 degree pixel scales, which is ill-defined for image with more than 180 pixels.

## Solution Description

We adopt a pseudo-Euclidean Carée projection at Ra/DEC=180/0 and a 1 arcsec/pixel resolution. Nobody could mistake this for anything other than a dummy, but it will not lead to improper behavior.