### PR TITLE
added diagnonalized Hessian

### DIFF
--- a/docs/0-example.ipynb
+++ b/docs/0-example.ipynb
@@ -376,7 +376,7 @@
     "            scene.sources[i] = scene.sources[i].replace(\"spectrum\", jnp.maximum(spectrum, tiny))\n",
     "        sc2.Parameter(\n",
     "            scene.sources[i].spectrum,\n",
-    "            name=f\"spectrum:{i}\",\n",
+    "            name=f\"spectrum_{i}\",\n",
     "            constraint=constraints.positive,\n",
     "            stepsize=spec_step,\n",
     "        )\n",
@@ -389,7 +389,7 @@
     "                scene.sources[i] = scene.sources[i].replace(\"morphology\", jnp.clip(morph, tiny, 1-tiny))\n",
     "            sc2.Parameter(\n",
     "                scene.sources[i].morphology,\n",
-    "                name=f\"morph:{i}\",\n",
+    "                name=f\"morph_{i}\",\n",
     "                constraint=constraints.unit_interval,\n",
     "                stepsize=morph_step,\n",
     "            )"
@@ -399,7 +399,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The parameters are now attached to `scene`, and can be accessed with `scene.parameters`.\n",
+    "The parameters are now attached to `scene`, and can be accessed as a list with `scene.parameters`; individual parameters can also be looked up by their name, e.g.:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scene.get(\"spectrum_0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This array is identical to the one the tree node `scene.sources[0].spectrum`.\n",
+    "\n",
     "Now we can run the fitting method:"
    ]
   },
@@ -589,7 +606,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Other measurements (e.g. `centroid`) or {py:class}`~scarlet2.measure.Moments` are also implemented:"
+    "Other measurements (e.g. {py:func}`~scarlet2.mesure.centroid` or {py:class}`~scarlet2.measure.Moments`) are also implemented:"
    ]
   },
   {
@@ -607,6 +624,73 @@
    "metadata": {},
    "source": [
     "All of these measurements are ordered by channel, so the ellipticity above is listed as `[[e1_g, e1_r, e1_i, e1_z, e1_y],[e2_g, e2_r, e2_i, e2_z, e2_y]]`. That they are all the same should not come as a surprise: For single-component models, there is no variation of the morphology across the channels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
+   "source": [
+    "### Parameter Uncertainties\n",
+    "\n",
+    "With an optimized model, we can estimate the uncertainties of the model parameters through the curvature of the log-likelihood function. The function {py:func}`scarlet2.infer.uncertainty` returns Gaussian $1\\sigma$ uncertainties as a dictionary, keyed with the names of the parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigmas = sc2.infer.uncertainty(scene_, obs)\n",
+    "print(f\"------------------------ {channels}\")\n",
+    "for k, src in enumerate(scene_.sources):\n",
+    "    sigma = sigmas.get(f\"spectrum_{k}\")\n",
+    "    print(f\"Source {k} spectrum sigma: {sigma}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# show the significant pixels of the source 3 morphology\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.imshow(scene_.get(\"morph_3\") > 2*sigmas.get(\"morph_3\"));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These estimates are approximate for several reasons. The method only computes the _diagonal_ elements of the Hessian of the loss function (which means all parameters and parameter elements are considered independent), and even those are estimated from a finite number of samples. In addition, the loss can only estimate the statistical uncertainties and is blind to systematic biases. So, this method can provide rough estimates of the error propagation from the data into the parameters; for more precise estimates, follow the [posterior sampling guide](howto/posterior).\n",
+    "\n",
+    "If we want uncertainties on source measurements (e.g. the flux), we need to propagate the uncertainties  from all parameters forward to the level of the source models, and then measure the flux for these model \"variants\". We can do so by running this method and asking for samples from the underlying Gaussian distributions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create 10 samples from all parameters\n",
+    "S = 10\n",
+    "samples = sc2.infer.uncertainty(scene_, obs, return_samples=S)\n",
+    "# convert dict of lists to list of dicts\n",
+    "samples = [dict(zip(samples,s)) for s in zip(*samples.values())]\n",
+    "# each element of samples is now 1 draw for all parameters\n",
+    "# insert them into the scene as 1 variant that is consistent with the data\n",
+    "scenes = [scene_.set(s) for s in samples]\n",
+    "# measure the flux for each source in each scene sample\n",
+    "fluxes = [[sc2.measure.flux(s.sources[k]) for s in scenes] for k in range(len(scene_.sources))]\n",
+    "\n",
+    "print(f\"-------------------- {channels}\")\n",
+    "for k, flux_k in enumerate(fluxes):\n",
+    "    sigma = jnp.std(jnp.array(flux_k), axis=0)\n",
+    "    print(f\"Source {k} flux sigma: {sigma}\")"
    ]
   },
   {
@@ -635,7 +719,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The stored model be loaded in the same way. Every source can be utilized as before."
+    "The stored model can be loaded in the same way, and then every source can be utilized as before."
    ]
   },
   {

--- a/docs/0-example.ipynb
+++ b/docs/0-example.ipynb
@@ -415,7 +415,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This array is identical to the one the tree node `scene.sources[0].spectrum`.\n",
+    "This array is identical to the tree node `scene.sources[0].spectrum`, with which it was defined.\n",
     "\n",
     "Now we can run the fitting method:"
    ]
@@ -606,7 +606,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Other measurements (e.g. {py:func}`~scarlet2.mesure.centroid` or {py:class}`~scarlet2.measure.Moments`) are also implemented:"
+    "Other measurements (e.g. {py:func}`~scarlet2.measure.centroid` or {py:class}`~scarlet2.measure.Moments`) are also implemented:"
    ]
   },
   {
@@ -628,13 +628,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "### Parameter Uncertainties\n",
     "\n",
-    "With an optimized model, we can estimate the uncertainties of the model parameters through the curvature of the log-likelihood function. The function {py:func}`scarlet2.infer.uncertainty` returns Gaussian $1\\sigma$ uncertainties as a dictionary, keyed with the names of the parameters:"
+    "With an optimized model, we can estimate the uncertainties of the model parameters through the curvature of the loss surface. The function {py:func}`scarlet2.infer.uncertainty` returns Gaussian $1\\sigma$ uncertainties as a dictionary, keyed with the names of the parameters:"
    ]
   },
   {
@@ -665,9 +663,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "These estimates are approximate for several reasons. The method only computes the _diagonal_ elements of the Hessian of the loss function (which means all parameters and parameter elements are considered independent), and even those are estimated from a finite number of samples. In addition, the loss can only estimate the statistical uncertainties and is blind to systematic biases. So, this method can provide rough estimates of the error propagation from the data into the parameters; for more precise estimates, follow the [posterior sampling guide](howto/posterior).\n",
+    "These estimates are approximate for several reasons. The method only computes the _diagonal_ elements of the Hessian of the loss function (which means all parameters and parameter elements are considered independent), and even those are estimated from a finite number of samples. In addition, the loss can only estimate the statistical uncertainties and is blind to systematic biases. So, this method can provide rough estimates of the error propagation from the data into the parameters; for more precise estimates, follow the [posterior sampling guide](howto/sampling).\n",
     "\n",
-    "If we want uncertainties on source measurements (e.g. the flux), we need to propagate the uncertainties  from all parameters forward to the level of the source models, and then measure the flux for these model \"variants\". We can do so by running this method and asking for samples from the underlying Gaussian distributions:"
+    "If we want uncertainties on source measurements (e.g. the flux), we need to propagate the uncertainties  from all parameters forward to the level of the source models, and then measure the flux for these model \"variants\". We can do so by running the `uncertainty` method with the `return_samples` option, which give returns a dictionary of samples from the respective Gaussian distributions:"
    ]
   },
   {

--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -271,7 +271,7 @@
     "        sc2.Parameter(\n",
     "            scene.sources[i].morphology,\n",
     "            name=f\"morph:{i}\",\n",
-    "            constraint=constraints.unit_interval,\n",
+    "            constraint=constraints.positive,#unit_interval,\n",
     "            stepsize=morph_step,\n",
     "        )"
    ]
@@ -408,6 +408,63 @@
    "metadata": {},
    "source": [
     "Not perfect, but close. We can see that source 0 \"steals\" a bit of light from source 1, and, as we saw above, both are somewhat affected by noise. In other tutorials we will see how to manage these tendencies, either by using more restrictive parametric models or neural network priors. But this example demonstrates that even with no model assumptions and minimal constraints, the data alone are already highly informative. We just needed a properly specified model, the likelihood optimization did the rest."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70c5c3f6-2ab1-4ae3-b20f-944f236249c9",
+   "metadata": {},
+   "source": [
+    "## Parameter Uncertainties\n",
+    "\n",
+    "With an optimized model, we can compute the uncertainties of the model parameters through the curvature $H$ of the log-likelihood function, which can be associated with the Gaussian $1\\sigma$ uncertainties according to $\\sigma=1/\\sqrt{H}$. The function {py:func}`scarlet2.infer.uncertainty`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dff11c22-a965-4702-9961-c7225be8e2a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors = sc2.infer.uncertainty(scene_, obs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a33b92a8-d745-42d9-9dd8-11e64da4f43c",
+   "metadata": {},
+   "source": [
+    "The function returns a dictionary, keyed with the names of the parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f262d08e-1054-446d-ae78-f88ca430cad5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errors.get(\"spectrum_0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3e3eb41-7308-46eb-9c5a-448b99247ac8",
+   "metadata": {},
+   "source": [
+    "which can be used directly or to visualize the significance of the morphology:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26afbfad-ce9d-49bb-a40a-fc0e0c7b3795",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.imshow(scene_.get(\"morph_0\") > 2 * errors.get(\"morph_0\"));"
    ]
   }
  ],

--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -63,7 +63,7 @@
     "    data = data + spectrum[:, None, None] * morph[None]\n",
     "\n",
     "# Add Gaussian noise\n",
-    "key = jax.random.key(42)\n",
+    "key = jax.random.key(0)\n",
     "noise = jax.random.normal(key, data.shape) * noise_sigma\n",
     "data = data + noise\n",
     "weights = jnp.full(data.shape, 1 / noise_sigma ** 2)"
@@ -271,7 +271,7 @@
     "        sc2.Parameter(\n",
     "            scene.sources[i].morphology,\n",
     "            name=f\"morph:{i}\",\n",
-    "            constraint=constraints.positive,#unit_interval,\n",
+    "            constraint=constraints.unit_interval,\n",
     "            stepsize=morph_step,\n",
     "        )"
    ]
@@ -394,12 +394,12 @@
     "    for spectrum, sigma in zip(true_spectra, sigmas)\n",
     "]\n",
     "\n",
-    "print(f\"{'':12s}  {'b':>10s}  {'g':>10s}  {'r':>10s}\")\n",
+    "print(f\"{'':16s}  {'b':>10s}  {'g':>10s}  {'r':>10s}\")\n",
     "for k, src in enumerate(scene_.sources):\n",
     "    recovered = sc2.measure.flux(src)\n",
     "    true = true_fluxes[k]\n",
-    "    print(f\"Source {k} true:    {true[0]:10.2f}  {true[1]:10.2f}  {true[2]:10.2f}\")\n",
-    "    print(f\"Source {k} modeled: {recovered[0]:10.2f}  {recovered[1]:10.2f}  {recovered[2]:10.2f}\")"
+    "    print(f\"Source {k} true flux:    {true[0]:10.2f}  {true[1]:10.2f}  {true[2]:10.2f}\")\n",
+    "    print(f\"Source {k} modeled flux: {recovered[0]:10.2f}  {recovered[1]:10.2f}  {recovered[2]:10.2f}\")"
    ]
   },
   {
@@ -408,63 +408,6 @@
    "metadata": {},
    "source": [
     "Not perfect, but close. We can see that source 0 \"steals\" a bit of light from source 1, and, as we saw above, both are somewhat affected by noise. In other tutorials we will see how to manage these tendencies, either by using more restrictive parametric models or neural network priors. But this example demonstrates that even with no model assumptions and minimal constraints, the data alone are already highly informative. We just needed a properly specified model, the likelihood optimization did the rest."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "70c5c3f6-2ab1-4ae3-b20f-944f236249c9",
-   "metadata": {},
-   "source": [
-    "## Parameter Uncertainties\n",
-    "\n",
-    "With an optimized model, we can compute the uncertainties of the model parameters through the curvature $H$ of the log-likelihood function, which can be associated with the Gaussian $1\\sigma$ uncertainties according to $\\sigma=1/\\sqrt{H}$. The function {py:func}`scarlet2.infer.uncertainty`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dff11c22-a965-4702-9961-c7225be8e2a1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "errors = sc2.infer.uncertainty(scene_, obs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a33b92a8-d745-42d9-9dd8-11e64da4f43c",
-   "metadata": {},
-   "source": [
-    "The function returns a dictionary, keyed with the names of the parameters:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f262d08e-1054-446d-ae78-f88ca430cad5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "errors.get(\"spectrum_0\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b3e3eb41-7308-46eb-9c5a-448b99247ac8",
-   "metadata": {},
-   "source": [
-    "which can be used directly or to visualize the significance of the morphology:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26afbfad-ce9d-49bb-a40a-fc0e0c7b3795",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "plt.imshow(scene_.get(\"morph_0\") > 2 * errors.get(\"morph_0\"));"
    ]
   }
  ],

--- a/docs/0-quickstart.ipynb
+++ b/docs/0-quickstart.ipynb
@@ -281,7 +281,7 @@
    "id": "20",
    "metadata": {},
    "source": [
-    "We can now run the fitting method. We use `optax.adam` as the optimizer, which will employ the parameter-specific stepsizes as defined above."
+    "We can now run the fitting method, which uses `optax.yogi` as the optimizer and employx the parameter-specific stepsizes as defined above:"
    ]
   },
   {

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,7 @@ API Documentation
    scarlet2.constraint
    scarlet2.detect
    scarlet2.fft
+   scarlet2.infer
    scarlet2.init
    scarlet2.interpolation
    scarlet2.io
@@ -24,4 +25,3 @@ API Documentation
    scarlet2.plot
    scarlet2.renderer
    scarlet2.wavelets
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,14 @@ issues_github_path = "pmelchior/scarlet2"
 nb_execution_timeout = 60
 nb_execution_excludepatterns = ["_build", "jupyter_execute"]
 
+# MyST parser extensions (myst-nb uses the MyST Markdown parser for notebooks).
+# "dollarmath" enables $...$ inline and $$...$$ block math like JupyterLab;
+# "amsmath" enables LaTeX environments such as \begin{align}.
+myst_enable_extensions = [
+    "dollarmath",
+    "amsmath",
+]
+
 # Napoleon settings
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,38 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import os
+
+# -- Example data ------------------------------------------------------------
+# The notebooks download their data with hf_hub_download. Each notebook runs in
+# its own kernel, and every call hits the Hub with a HEAD request even when the
+# file is already cached, which trips the anonymous per-IP rate limit (429).
+# Fetch each file once here, then put the notebook kernels into offline mode so
+# they read straight from the local cache without any further requests.
+HF_REPO_ID = "astro-data-lab/scarlet-test-data"
+HF_FILES = [
+    "hsc_cosmos_35.npz",
+    "lsbg.pkl",
+    "multiresolution_tutorial/data.fits.gz",
+    "transient_tutorial/data.fits.gz",
+]
+
+
+def _prefetch_example_data():
+    from huggingface_hub import hf_hub_download
+
+    for filename in HF_FILES:
+        hf_hub_download(repo_id=HF_REPO_ID, filename=filename, repo_type="dataset")
+
+
+try:
+    _prefetch_example_data()
+except Exception as e:  # noqa: BLE001
+    # Let the notebooks try on their own rather than failing the whole build.
+    print(f"WARNING: could not prefetch example data ({e}); notebooks will download individually")
+else:
+    os.environ["HF_HUB_OFFLINE"] = "1"
+
 # -- Project information -----------------------------------------------------
 
 project = "scarlet2"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,20 +13,25 @@ import os
 # file is already cached, which trips the anonymous per-IP rate limit (429).
 # Fetch each file once here, then put the notebook kernels into offline mode so
 # they read straight from the local cache without any further requests.
-HF_REPO_ID = "astro-data-lab/scarlet-test-data"
+# (repo_id, filename, repo_type) for every file the notebooks pull from the Hub.
+# The "model" files are the galaxygrad score-based priors used in priors.ipynb;
+# galaxygrad fetches them internally via hf_hub_download, so prefetching them
+# here populates the same cache and lets that notebook run offline too.
 HF_FILES = [
-    "hsc_cosmos_35.npz",
-    "lsbg.pkl",
-    "multiresolution_tutorial/data.fits.gz",
-    "transient_tutorial/data.fits.gz",
+    ("astro-data-lab/scarlet-test-data", "hsc_cosmos_35.npz", "dataset"),
+    ("astro-data-lab/scarlet-test-data", "lsbg.pkl", "dataset"),
+    ("astro-data-lab/scarlet-test-data", "multiresolution_tutorial/data.fits.gz", "dataset"),
+    ("astro-data-lab/scarlet-test-data", "transient_tutorial/data.fits.gz", "dataset"),
+    ("sampsonML/galaxy-score-based-diffusion-models", "eqx_hsc_ScoreNet32.eqx", "model"),
+    ("sampsonML/galaxy-score-based-diffusion-models", "eqx_hsc_ScoreNet64.eqx", "model"),
 ]
 
 
 def _prefetch_example_data():
     from huggingface_hub import hf_hub_download
 
-    for filename in HF_FILES:
-        hf_hub_download(repo_id=HF_REPO_ID, filename=filename, repo_type="dataset")
+    for repo_id, filename, repo_type in HF_FILES:
+        hf_hub_download(repo_id=repo_id, filename=filename, repo_type=repo_type)
 
 
 try:

--- a/docs/howto/multiresolution.ipynb
+++ b/docs/howto/multiresolution.ipynb
@@ -423,7 +423,7 @@
     "Because the astrometric offset is relative, it's sufficient to only shift one observation (or more precisely: all but one). The observation whose `shift` we do not adjust thus defines the astrometric reference. Without this fixed anchor, all observations can be shifted by an arbitary amount, which would make the fitter or sampler unhappy: it's a perfect degeneracy.\n",
     "```\n",
     "\n",
-    "So let's define the shift parameter for the HSC observation only, and fit the same scene again. As we will update scene _and_ observations, we need the more flexible fitting function {py:func}`scarlet2.fit` rather than `scene.fit`."
+    "So let's define the shift parameter for the HSC observation only, and fit the same scene again. As we will update scene _and_ observations, we need the more flexible fitting function {py:func}`scarlet2.infer.fit` rather than `scene.fit`."
    ]
   },
   {
@@ -443,7 +443,7 @@
     "    sc2.Parameter(obs_hsc_corr.renderer[1].shift, name=\"shift\", stepsize=1e-3 * u.arcsec)\n",
     "\n",
     "# the more flexible fitter optimizes scene and observations and returns both\n",
-    "scene_, (_, obs_hsc_corr_) = sc2.fit(scene_, [obs_hst_corr, obs_hsc_corr], e_rel=1e-4, max_iter=1000)\n",
+    "scene_, (_, obs_hsc_corr_) = sc2.infer.fit(scene_, [obs_hst_corr, obs_hsc_corr], e_rel=1e-4, max_iter=1000)\n",
     "\n",
     "# get the astrometry shift\n",
     "shift = obs_hsc_corr_.get(\"shift\")\n",

--- a/docs/howto/priors.ipynb
+++ b/docs/howto/priors.ipynb
@@ -250,6 +250,11 @@
  ],
  "metadata": {
   "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -260,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/howto/priors.ipynb
+++ b/docs/howto/priors.ipynb
@@ -175,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "maxiter = 1000\n",
+    "maxiter = 200\n",
     "print(\"Initial chi^2:\", obs.goodness_of_fit(scene()))\n",
     "scene_ = scene.fit(obs, max_iter=maxiter, e_rel=1e-4, progress_bar=True)\n",
     "print(\"Optimized chi^2:\", obs.goodness_of_fit(scene_()))"

--- a/docs/howto/sampling.ipynb
+++ b/docs/howto/sampling.ipynb
@@ -147,7 +147,7 @@
     "\n",
     "## Run Sampler\n",
     "\n",
-    "Then we can run numpyro's {py:class}`~numpyro.infer.hmc.NUTS` sampler with a call to {py:func}`~scarlet2.sample`:"
+    "Then we can run numpyro's {py:class}`~numpyro.infer.hmc.NUTS` sampler with a call to {py:func}`~scarlet2.infer.sample`:"
    ]
   },
   {
@@ -156,8 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mcmc = sc2.sample(\n",
-    "    scene,\n",
+    "mcmc = scene.sample(\n",
     "    obs,\n",
     "    num_warmup=100,\n",
     "    num_samples=1000,\n",
@@ -261,6 +260,11 @@
  ],
  "metadata": {
   "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -271,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ ipywidgets
 corner
 arviz
 galaxygrad >= 0.3.0
+huggingface_hub

--- a/src/scarlet2/__init__.py
+++ b/src/scarlet2/__init__.py
@@ -42,7 +42,7 @@ __citation__ = __bibtex__ = (Path(__file__).parent / "citation.bib").read_text()
 
 from .bbox import Box
 from .frame import Frame
-from .infer import PairSimilarity, fit, sample
+from .infer import PairSimilarity
 from .module import Module, Parameter, Parameters, relative_step
 from .morphology import (
     GaussianMorphology,
@@ -56,51 +56,45 @@ from .psf import PSF, ArrayPSF, GaussianPSF
 from .scene import Scene
 from .source import Component, DustComponent, PointSource, Source
 from .spectrum import Spectrum, StaticArraySpectrum, TransientArraySpectrum
-from .validation import check_fit, check_observation, check_scene, check_source
-from .validation_utils import VALIDATION_SWITCH, set_validation
+from .validation_utils import set_validation
 from .wavelets import Starlet
 
 # for * imports and docs
 __all__ = [
     "constraint",
     "detect",
+    "infer",
     "init",
     "measure",
     "plot",
-    "fit",
-    "sample",
-    "PairSimilarity",
-    "Scenery",
-    "Parameterization",
+    "validation",
+    "ArrayPSF",
     "Box",
+    "Component",
+    "CorrelatedObservation",
+    "DustComponent",
     "Frame",
-    "Parameter",
-    "Parameters",
+    "GaussianMorphology",
+    "GaussianPSF",
     "Module",
     "Morphology",
-    "ProfileMorphology",
-    "GaussianMorphology",
-    "SersicMorphology",
-    "StarletMorphology",
     "Observation",
-    "CorrelatedObservation",
-    "PSF",
-    "ArrayPSF",
-    "GaussianPSF",
-    "Scene",
-    "Component",
-    "DustComponent",
-    "Source",
+    "PairSimilarity",
+    "Parameter",
+    "Parameterization",
+    "Parameters",
     "PointSource",
+    "ProfileMorphology",
+    "PSF",
+    "Scene",
+    "Scenery",
+    "SersicMorphology",
+    "Source",
     "Spectrum",
+    "Starlet",
+    "StarletMorphology",
     "StaticArraySpectrum",
     "TransientArraySpectrum",
-    "Starlet",
-    "check_fit",
-    "check_observation",
-    "check_scene",
-    "check_source",
     "relative_step",
     "set_validation",
-    "VALIDATION_SWITCH",
 ]

--- a/src/scarlet2/__init__.py
+++ b/src/scarlet2/__init__.py
@@ -29,8 +29,6 @@ class Parameterization:
 parameter_registry = dict()
 
 
-from . import constraint, detect, init, measure, plot
-
 try:
     from ._version import __version__
 except ImportError:
@@ -40,6 +38,7 @@ from pathlib import Path
 
 __citation__ = __bibtex__ = (Path(__file__).parent / "citation.bib").read_text()
 
+from . import constraint, detect, infer, init, measure, plot
 from .bbox import Box
 from .frame import Frame
 from .infer import PairSimilarity
@@ -67,7 +66,6 @@ __all__ = [
     "init",
     "measure",
     "plot",
-    "validation",
     "ArrayPSF",
     "Box",
     "Component",
@@ -98,3 +96,23 @@ __all__ = [
     "relative_step",
     "set_validation",
 ]
+
+from warnings import warn
+
+
+def fit(*args, **kwargs):
+    warn(
+        "`scarlet2.fit` is deprecated, use `scarlet2.infer.fit` instead!",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return infer.fit(*args, **kwargs)
+
+
+def sample(*args, **kwargs):
+    warn(
+        "`scarlet2.sample` is deprecated, use `scarlet2.infer.sample` instead!",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return infer.sample(*args, **kwargs)

--- a/src/scarlet2/infer.py
+++ b/src/scarlet2/infer.py
@@ -1,3 +1,5 @@
+"""Inference methods"""
+
 import functools
 import operator
 from pprint import pformat
@@ -611,13 +613,21 @@ def hvp_rad(hvp, shape, key=None, max_iter=100):
     return h / max_iter
 
 
-def uncertainty(scene, observations, pair_similarity=None, max_iter=100, return_hessian=False):
+def uncertainty(
+    scene,
+    observations,
+    pair_similarity=None,
+    max_iter=100,
+    return_hessian=False,
+    return_samples=False,
+    key=None,
+):
     """Estimate the per-parameter curvature (diagonal Hessian) of a fitted model.
 
     Computes the diagonal of the Hessian of the negative log-posterior loss
     (:func:`_loss_fn`) at the current (assumed best-fit) parameter values, i.e.
     the local marginal precision of each parameter. Under a Laplace
-    approximation the "1-sigma" uncertainty of a parameter is ``1 / sqrt(H)``
+    approximation the "1-sigma" uncertainty of a parameter is $1 / sqrt(H)$
     for the corresponding (positive) diagonal entry.
 
     If ``return_hessian`` is ``True``,  the raw Hessian curvature is returned
@@ -629,6 +639,10 @@ def uncertainty(scene, observations, pair_similarity=None, max_iter=100, return_
     (:func:`hvp`). Every non-fixed parameter of ``scene`` and ``observations``
     is flattened into a single vector, so the estimate is taken jointly across
     all parameters.
+
+    The Hessian is evaluated in the unconstrained space and transformed via the exact
+    change-of-variables ``H_phi = H_theta / (d phi / d theta)^2`` (valid at
+    an extremum). Parameters without a constraint are returned unchanged.
 
     Parameters
     ----------
@@ -644,15 +658,18 @@ def uncertainty(scene, observations, pair_similarity=None, max_iter=100, return_
         Maximum number of Rademacher probes to estimate the Hessian diagonal.
     return_hessian : bool, optional
         If ``True``, return the raw Hessian diagonal rather than the uncertainty (1/sqrt(H)).
+    return_samples: bool or int
+        If not ``False``, return the stated number samples according to the Gaussian uncertainties.
+        The dictionary has the same shape as flattened chains from :func:`sample`.
+    key : jax.random.PRNGKey, optional
+        A random key for generating Rademacher vectors. If None, a new key will be generated.
 
     Returns
     -------
     dict
-        Maps every non-fixed parameter name to the diagonal uncertainty/Hessian of the same
+        Maps every non-fixed parameter name to the diagonal uncertainty of the same
         shape as the parameter, expressed in the natural (constrained) parameter
-        space. The Hessian is evaluated in the unconstrained space and transformed via the exact
-        change-of-variables ``H_phi = H_theta / (d phi / d theta)^2`` (valid at
-        an extremum). Parameters without a constraint are returned unchanged.
+        space.
     """
     # making sure we can iterate
     if not isinstance(observations, (list, tuple)):
@@ -693,8 +710,10 @@ def uncertainty(scene, observations, pair_similarity=None, max_iter=100, return_
     loss_fn = lambda x: _loss_fn(unravel(x), params, scene, observations, pair_cfg)[0]
 
     # jit the Hessian-vector product so the ~max_iter Hutchinson probes reuse one compile
+    if key is None:
+        key = jax.random.PRNGKey(0)
     hvp_z = jax.jit(lambda z: hvp(loss_fn, (flat,), (z,)))
-    diag = hvp_rad(hvp_z, flat.shape, max_iter=max_iter)
+    diag = hvp_rad(hvp_z, flat.shape, key=key, max_iter=max_iter)
 
     # unconstrained-space diagonal Hessian, as a parameter tree
     diag_u = unravel(diag)
@@ -714,8 +733,22 @@ def uncertainty(scene, observations, pair_similarity=None, max_iter=100, return_
 
     if return_hessian:
         return {name: getattr(hess, name) for name in value_names}
+
     # uncertainty = 1/sqrt(H) in the natural (constrained) space
-    return {name: 1 / jnp.sqrt(getattr(hess, name)) for name in value_names}
+    def sigma(h):
+        # remove unreliable Hessian elements
+        h_0 = h[h > 0]
+        med = jnp.median(h_0)
+        std = jnp.std(h_0)
+        h = jnp.where((h > 0) & (jnp.abs(h - med) < 10 * std), h, med)
+        return 1 / jnp.sqrt(h)
+
+    errors = {name: sigma(getattr(hess, name)) for name in value_names}
+    if return_samples is False:
+        return errors
+    normals = {name: dist.Normal(scene.get(name), scale=errors.get(name)).to_event(1) for name in errors}
+    # dictionary: parameter name -> sampled values
+    return {name: normals[name].sample(key, sample_shape=(return_samples,)) for name in errors}
 
 
 class FitValidator(metaclass=ValidationMethodCollector):

--- a/src/scarlet2/infer.py
+++ b/src/scarlet2/infer.py
@@ -9,6 +9,7 @@ import jax.tree as jt
 import numpyro
 import numpyro.distributions as dist
 import numpyro.distributions.constraints as constraints
+from jax.flatten_util import ravel_pytree
 from numpyro.infer import MCMC, NUTS
 
 from .scene import Scene
@@ -493,44 +494,7 @@ def _build_optim(kwargs_items, schedule):
 def _make_step(
     values, params, scene, observations, optim, opt_state, steps, best_loss, best_values, pair_cfg
 ):
-    def loss_fn(values):
-        # parameters now obey constraints
-        # transformation happens in the grad path, so gradients are wrt to unconstrained variables
-        # likelihood and prior grads transparently apply the Jacobians of these transformations
-        values_ = _constraint_replace(values, params)
-        scene_ = scene.set(values_)
-        # If any regularizer is active, we need the per-source stack anyway —
-        # build it once and reuse its sum as the model so we don't loop over
-        # sources twice.
-        needs_per_source = pair_cfg.weight != 0.0
-        if needs_per_source:
-            per_source = _evaluate_per_source(scene_)
-            model = per_source.sum(axis=0)
-        else:
-            per_source = None
-            model = scene_()
-        log_like = sum(obs.set(values_).log_likelihood(model) for obs in observations)
-
-        # add log prior for all parameters which define priors
-        # Note: This calls priors separately even if they support batched execution
-        # see https://github.com/pmelchior/scarlet2/issues/103 for a possible solution
-        # however, testing after #103 got merged suggests that tree_reduce is faster than grouping
-        log_prior = jt.reduce(
-            operator.add,
-            jt.map(
-                lambda value, param: param.prior.log_prob(value) if param.prior is not None else 0,
-                values_,
-                params,
-            ),
-        )
-
-        # pair-similarity regularizer (no-op when pair_cfg.weight == 0.0)
-        pair = _pair_similarity_penalty(scene_, pair_cfg, per_source=per_source)
-
-        # has_aux=True: return penalty values alongside the loss so they can be
-        # tracked in fit_info without a second forward pass
-        return -(log_like + log_prior) + pair, (pair,)
-
+    loss_fn = lambda values: _loss_fn(values, params, scene, observations, pair_cfg)
     (loss, (pair,)), grads = eqx.filter_value_and_grad(loss_fn, has_aux=True)(values)
     updates, opt_state = optim.update(grads, opt_state, values)
     # apply per-parameter stepsizes; minus sign because we want gradient descent
@@ -554,6 +518,204 @@ def _make_step(
     best_values = jt.map(lambda b, v: jnp.where(is_better, v, b), best_values, values)
 
     return values_, loss, pair, opt_state, convergence, best_loss, best_values
+
+
+# loss function for the optimizer;
+# returns the loss and a tuple of aux values (pair-similarity penalty) for tracking in fit_info
+def _loss_fn(values, params, scene, observations, pair_cfg):
+    # parameters now obey constraints
+    # transformation happens in the grad path, so gradients are wrt to unconstrained variables
+    # likelihood and prior grads transparently apply the Jacobians of these transformations
+    values_ = _constraint_replace(values, params)
+    scene_ = scene.set(values_)
+    # If any regularizer is active, we need the per-source stack anyway —
+    # build it once and reuse its sum as the model so we don't loop over
+    # sources twice.
+    needs_per_source = pair_cfg.weight != 0.0
+    if needs_per_source:
+        per_source = _evaluate_per_source(scene_)
+        model = per_source.sum(axis=0)
+    else:
+        per_source = None
+        model = scene_()
+    log_like = sum(obs.set(values_).log_likelihood(model) for obs in observations)
+
+    # add log prior for all parameters which define priors
+    # Note: This calls priors separately even if they support batched execution
+    # see https://github.com/pmelchior/scarlet2/issues/103 for a possible solution
+    # however, testing after #103 got merged suggests that tree_reduce is faster than grouping
+    log_prior = jt.reduce(
+        operator.add,
+        jt.map(
+            lambda value, param: param.prior.log_prob(value) if param.prior is not None else 0,
+            values_,
+            params,
+        ),
+    )
+
+    # pair-similarity regularizer (no-op when pair_cfg.weight == 0.0)
+    pair = _pair_similarity_penalty(scene_, pair_cfg, per_source=per_source)
+
+    # has_aux=True: return penalty values alongside the loss so they can be
+    # tracked in fit_info without a second forward pass
+    return -(log_like + log_prior) + pair, (pair,)
+
+
+# Compute Hessian-vector products (HVPs) using JAX's jvp and grad.
+# for regular functions f
+def hvp(f, primals, tangents):
+    """Calculate the Hessian-vector product of a function f"""
+    return jax.jvp(jax.grad(f), primals, tangents)[1]
+
+
+# for score functions
+def hvp_grad(grad_f, primals, tangents):
+    """Calculate the Hessian-vector product of a gradient function grad_f"""
+    return jax.jvp(grad_f, primals, tangents)[1]
+
+
+# diagonals of Hessian from HVPs
+def hvp_rad(hvp, shape, key=None, max_iter=100):
+    """Approximate the diagonal of the Hessian
+
+    Uses the Hutchinson's method to approximate the diagonal of the Hessian by computing the
+    Hessian-vector products with random Rademacher vectors.
+
+    Parameters
+    ----------
+    hvp : callable
+        A function that computes the Hessian-vector product.
+    shape : tuple
+        The shape of the input to the Hessian-vector product function.
+    key : jax.random.PRNGKey, optional
+        A random key for generating Rademacher vectors. If None, a new key will be generated.
+    max_iter : int, optional
+        The maximum number of iterations for the approximation. Default is 100.
+
+    Returns
+    -------
+    jax.numpy.ndarray
+        An array containing the approximate diagonal of the Hessian.
+    """
+    h = jnp.zeros(shape, dtype=jnp.float32)
+    if key is None:
+        key = jax.random.PRNGKey(0)
+
+    # Fixed-length loop (no data-dependent early stop) so this is jittable. A fresh
+    # Rademacher probe per iteration is essential: reusing one `key` would draw the
+    # same vector every time and never average out the off-diagonal contamination.
+    for _ in range(max_iter):
+        key, subkey = jax.random.split(key)
+        z = jax.random.rademacher(subkey, shape, dtype=jnp.float32)
+        h += jnp.multiply(z, hvp(z))
+    return h / max_iter
+
+
+def uncertainty(scene, observations, pair_similarity=None, max_iter=100, return_hessian=False):
+    """Estimate the per-parameter curvature (diagonal Hessian) of a fitted model.
+
+    Computes the diagonal of the Hessian of the negative log-posterior loss
+    (:func:`_loss_fn`) at the current (assumed best-fit) parameter values, i.e.
+    the local marginal precision of each parameter. Under a Laplace
+    approximation the "1-sigma" uncertainty of a parameter is ``1 / sqrt(H)``
+    for the corresponding (positive) diagonal entry.
+
+    If ``return_hessian`` is ``True``,  the raw Hessian curvature is returned
+    instead so the caller can handle non-positive entries (a direction not at a
+    minimum) explicitly rather than receiving NaNs from the square root.
+
+    The Hessian diagonal is estimated stochastically with Hutchinson's method
+    (:func:`hvp_rad`) applied to the Hessian-vector product of :func:`_loss_fn`
+    (:func:`hvp`). Every non-fixed parameter of ``scene`` and ``observations``
+    is flattened into a single vector, so the estimate is taken jointly across
+    all parameters.
+
+    Parameters
+    ----------
+    scene : :py:class:`~scarlet2.Scene`
+        The (fitted) model of the scene.
+    observations : :py:class:`~scarlet2.Observation` or list
+        The observations the model was fit to.
+    pair_similarity : :py:class:`~scarlet2.PairSimilarity`, optional
+        Same regularizer configuration as passed to :func:`fit`. Must match
+        what was used during fitting so that the loss (and hence its Hessian)
+        is identical. ``None`` (default) disables it.
+    max_iter : int, optional
+        Maximum number of Rademacher probes to estimate the Hessian diagonal.
+    return_hessian : bool, optional
+        If ``True``, return the raw Hessian diagonal rather than the uncertainty (1/sqrt(H)).
+
+    Returns
+    -------
+    dict
+        Maps every non-fixed parameter name to the diagonal uncertainty/Hessian of the same
+        shape as the parameter, expressed in the natural (constrained) parameter
+        space. The Hessian is evaluated in the unconstrained space and transformed via the exact
+        change-of-variables ``H_phi = H_theta / (d phi / d theta)^2`` (valid at
+        an extremum). Parameters without a constraint are returned unchanged.
+    """
+    # making sure we can iterate
+    if not isinstance(observations, (list, tuple)):
+        observations = (observations,)
+    obs_params = {}
+    for obs in observations:
+        obs.check_set_renderer(scene.frame)
+        obs_params.update(obs.parameters)
+
+    # scene and observations can have parameters: combine them into one model
+    parameters = scene.parameters | obs_params
+    if len(parameters) == 0:
+        msg = "Scene and Observation(s) must have at least one parameter. Found none."
+        raise AttributeError(msg)
+
+    # canonicalize like fit(): strip fit_info so the pytree/JIT cache key is stable
+    scene = scene.replace("fit_info", None)
+
+    values = scene.get()
+    for obs in observations:
+        values |= obs.get()
+    value_names = tuple(values.keys())
+
+    # construct eqx.Module containing all parameter arrays as attributes (as in fit)
+    values = _dict_to_eqx_module("ParamModel", values)
+    treedef = jt.structure(values)
+    params = tuple(param for name, (node, param) in parameters.items())
+    params = jt.unflatten(treedef, params)
+
+    # default: regularizer off (weight=0.0 short-circuits to a no-op)
+    pair_cfg = pair_similarity if pair_similarity is not None else PairSimilarity(weight=0.0)
+
+    # _loss_fn differentiates wrt unconstrained variables, so evaluate the Hessian there
+    values_u = _constraint_replace(values, params, inv=True)
+
+    # scalar loss over a single flat vector spanning all parameters
+    flat, unravel = ravel_pytree(values_u)
+    loss_fn = lambda x: _loss_fn(unravel(x), params, scene, observations, pair_cfg)[0]
+
+    # jit the Hessian-vector product so the ~max_iter Hutchinson probes reuse one compile
+    hvp_z = jax.jit(lambda z: hvp(loss_fn, (flat,), (z,)))
+    diag = hvp_rad(hvp_z, flat.shape, max_iter=max_iter)
+
+    # unconstrained-space diagonal Hessian, as a parameter tree
+    diag_u = unravel(diag)
+
+    # Transform the diagonal Hessian to the natural (constrained) space. At an
+    # extremum the score dL/dtheta vanishes, so the change-of-variables keeps only
+    # the quadratic term:
+    #     H_phi = H_theta (d theta / d phi)^2 = H_theta / (d phi / d theta)^2.
+    # The constraint bijectors are elementwise, so a jvp with unit tangents gives the
+    # per-element derivative jac = d(constrained)/d(unconstrained). Parameters without
+    # a constraint have jac == 1, so their curvature is returned unchanged. Keeping the
+    # Hessian (rather than converting to 1/sqrt(H)) avoids NaNs when a near-boundary
+    # constrained parameter has a small or slightly-negative unconstrained curvature.
+    ones = jt.map(jnp.ones_like, values_u)
+    _, jac = jax.jvp(lambda v: _constraint_replace(v, params), (values_u,), (ones,))
+    hess = jt.map(lambda h, j: h / j**2, diag_u, jac)
+
+    if return_hessian:
+        return {name: getattr(hess, name) for name in value_names}
+    # uncertainty = 1/sqrt(H) in the natural (constrained) space
+    return {name: 1 / jnp.sqrt(getattr(hess, name)) for name in value_names}
 
 
 class FitValidator(metaclass=ValidationMethodCollector):

--- a/src/scarlet2/infer.py
+++ b/src/scarlet2/infer.py
@@ -625,9 +625,9 @@ def uncertainty(
     """Estimate the per-parameter curvature (diagonal Hessian) of a fitted model.
 
     Computes the diagonal of the Hessian :math:`H` of the negative log-posterior loss
-    (:func:`_loss_fn`) at the current (assumed best-fit) parameter values, i.e.
+    at the current (assumed best-fit) parameter values of `scene`, which estimates
     the local marginal precision of each parameter. Under a Laplace
-    approximation the "1-sigma" uncertainty of a parameter is :math:`1 / \\sqrt(H)`
+    approximation the "1-sigma" uncertainty of a parameter is :math:`1 / \\sqrt{H}`
     for the corresponding (positive) diagonal entry.
 
     If ``return_hessian`` is ``True``,  the raw Hessian curvature is returned
@@ -641,7 +641,7 @@ def uncertainty(
     all parameters.
 
     If the loss contains priors (either per-parameter or pairwise), their
-    curvature will be taken into account: this method provide the curvature as
+    curvature will be taken into account: This method provide the curvature as
     experienced by the optimizer, not necessarily limited to the log-likelihood.
 
     The Hessian is evaluated in the unconstrained space and transformed via the exact

--- a/src/scarlet2/infer.py
+++ b/src/scarlet2/infer.py
@@ -624,10 +624,10 @@ def uncertainty(
 ):
     """Estimate the per-parameter curvature (diagonal Hessian) of a fitted model.
 
-    Computes the diagonal of the Hessian of the negative log-posterior loss
+    Computes the diagonal of the Hessian :math:`H` of the negative log-posterior loss
     (:func:`_loss_fn`) at the current (assumed best-fit) parameter values, i.e.
     the local marginal precision of each parameter. Under a Laplace
-    approximation the "1-sigma" uncertainty of a parameter is $1 / sqrt(H)$
+    approximation the "1-sigma" uncertainty of a parameter is :math:`1 / \\sqrt(H)`
     for the corresponding (positive) diagonal entry.
 
     If ``return_hessian`` is ``True``,  the raw Hessian curvature is returned
@@ -635,13 +635,17 @@ def uncertainty(
     minimum) explicitly rather than receiving NaNs from the square root.
 
     The Hessian diagonal is estimated stochastically with Hutchinson's method
-    (:func:`hvp_rad`) applied to the Hessian-vector product of :func:`_loss_fn`
-    (:func:`hvp`). Every non-fixed parameter of ``scene`` and ``observations``
+    (:func:`hvp_rad`) applied to the Hessian-vector product the loss function.
+    Every non-fixed parameter of ``scene`` and ``observations``
     is flattened into a single vector, so the estimate is taken jointly across
     all parameters.
 
+    If the loss contains priors (either per-parameter or pairwise), their
+    curvature will be taken into account: this method provide the curvature as
+    experienced by the optimizer, not necessarily limited to the log-likelihood.
+
     The Hessian is evaluated in the unconstrained space and transformed via the exact
-    change-of-variables ``H_phi = H_theta / (d phi / d theta)^2`` (valid at
+    change-of-variables :math:`H_\\phi = H_\\theta / (d \\phi / d \\theta)^2` (valid at
     an extremum). Parameters without a constraint are returned unchanged.
 
     Parameters

--- a/src/scarlet2/morphology.py
+++ b/src/scarlet2/morphology.py
@@ -3,7 +3,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.scipy
 
-from . import Scenery, measure
+from . import Scenery
 from .module import Module
 from .wavelets import starlet_reconstruction, starlet_transform
 
@@ -143,6 +143,8 @@ class GaussianMorphology(ProfileMorphology):
         -------
         GaussianMorphology
         """
+        from . import measure
+
         assert image.ndim == 2
         center = measure.centroid(image)
         # compute moments and create Gaussian from it

--- a/src/scarlet2/observation.py
+++ b/src/scarlet2/observation.py
@@ -115,7 +115,7 @@ class Observation(Module):
 
         For a Gaussian noise model, the gof is defined as the averaged squared deviation of the model from the
         data, scaled by the variance of the data, aka mean chi squared
-        :math:`\frac{1}{N}\\sum_i=1^N w_i (m_i - d_i)^2` with inverse variance weights :math:`w_i`.
+        :math:`\\frac{1}{N}\\sum_i=1^N w_i (m_i - d_i)^2` with inverse variance weights :math:`w_i`.
 
         Up to a normalization, the gof is identical to :py:class:`~scarlet2.Observation.log-likelihood`.
 


### PR DESCRIPTION
This PR adds the method `infer.uncertainty`, which computes the diagonalized Hessian and converts it to the 1-sigma uncertainty. This should only be used with an optimized model, so that the first-order (gradient) term vanishes.

The QuickStart guide shows the use of this method.