### PR TITLE
added per-channel shifts as option

### DIFF
--- a/src/scarlet2/interpolation.py
+++ b/src/scarlet2/interpolation.py
@@ -358,7 +358,8 @@ def resample_fourier(
     jacobian: jnp.array
         2x2 transformation matrix from warped to unwarped coordinates (in x/y convention)
     shift: tuple
-        Shift of the output image (in units of output pixels)
+        Shift of the output image (in units of output pixels), in (y, x) convention.
+        Either a single ``(2,)`` shift or per-channel shifts of shape ``(C, 2)``.
     interpolant: Interpolant
         Interpolation kernel function
 
@@ -401,8 +402,9 @@ def resample_fourier(
 
     # apply shift
     if shift is not None:
-        shift_ = shift[::-1]  # x,y needed here
-        pfac = jnp.exp(-1j * 2 * jnp.pi * (kcoords_out @ shift_))[..., :, :]
+        # shift is either (2,) for a common shift or (C, 2) for per-channel shifts, in (y, x) convention
+        shift_ = jnp.atleast_2d(shift)[:, ::-1]  # x,y needed here; (n, 2), n in {1, C}
+        pfac = jnp.exp(-1j * 2 * jnp.pi * jnp.einsum("yxi,ni->nyx", kcoords_out, shift_))
     else:
         pfac = 1
 

--- a/src/scarlet2/renderer.py
+++ b/src/scarlet2/renderer.py
@@ -156,7 +156,7 @@ class ConvolutionRenderer(Renderer):
         )
         self.kernel_fft = diff_kernel_fft
 
-        # for shift operations
+        # for shift operations: (2,) for a common shift, or (C, 2) for per-channel shifts
         self.shift = jnp.zeros(2)
         self._kcoords_out = jnp.stack(
             jnp.meshgrid(
@@ -171,7 +171,7 @@ class ConvolutionRenderer(Renderer):
         # apply shift to diff kernel
         return convolve(
             model,
-            self.kernel_fft * self._phase_factor[..., :, :],
+            self.kernel_fft * self._phase_factor,
             axes=(-2, -1),
             fft_shape=self._fft_shape,
         )
@@ -179,7 +179,10 @@ class ConvolutionRenderer(Renderer):
     @property
     def _phase_factor(self):
         # apply shift to frequencies in Fourier space
-        return jnp.exp(-1j * 2 * jnp.pi * (self._kcoords_out @ self.shift))
+        # self.shift is either (2,) for a common shift or (C, 2) for per-channel shifts, in (y, x) convention
+        shift = jnp.atleast_2d(self.shift)  # (n, 2), n in {1, C}
+        phase = jnp.einsum("yxi,ni->nyx", self._kcoords_out, shift)  # (n, fy, fx)
+        return jnp.exp(-1j * 2 * jnp.pi * phase)
 
 
 class TrimSpatialBox(Renderer):


### PR DESCRIPTION
## Change Description

Closes #286

## Solution Description

Simple replacement of a dot product with einsum to allow the shift computation for shifts of shape (2,) and (C, 2). The default remains at 2D; for now the user has to manually overwrite the array to get per-channel shifts.